### PR TITLE
DM-13887: Let ap_verify process multiple images per instance

### DIFF
--- a/python/lsst/ap/pipe/apPipeParser.py
+++ b/python/lsst/ap/pipe/apPipeParser.py
@@ -47,8 +47,8 @@ class ApPipeParser(pipeBase.ArgumentParser):
     def __init__(self, *args, **kwargs):
         pipeBase.ArgumentParser.__init__(
             self,
-            description="Process raw decam images with MasterCals "
-                        "from basic processing --> source association",
+            description="Process raw images through the AP pipeline "
+                        "from ISR through source association",
             *args,
             **kwargs)
         inputDataset = "raw"


### PR DESCRIPTION
This PR fixes a misprint in `ap_pipe.py`'s help text, discovered while debugging lsst/ap_verify#57.