### PR TITLE
DM-14019: Allow ap_pipe to skip association

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -193,11 +193,15 @@ class ApPipeTask(pipeBase.CmdLineTask):
         else:
             diffImResults = self.runDiffIm(calexpRef, templateIds)
 
-        # No reasonable way to check if Association can be skipped
-        associationResults = self.runAssociation(calexpRef)
+        if "associator" in reuse and \
+                daxPpdb.isVisitProcessed(self.ppdb, calexpRef.get("calexp_visitInfo")):
+            self.log.info("Association has already been run for {0}, skipping...".format(calexpRef.dataId))
+            associationResults = None
+        else:
+            associationResults = self.runAssociation(calexpRef)
 
         return pipeBase.Struct(
-            l1Database=associationResults.l1Database,
+            l1Database=self.ppdb,
             ccdProcessor=processResults if processResults else None,
             differencer=diffImResults if diffImResults else None,
             associator=associationResults.taskResults if associationResults else None


### PR DESCRIPTION
This PR lets association be skipped using the standard `--reuse-output-from` command-line argument; previously association would be rerun even if the user requested that it be skipped. Testing whether association has already been performed requires the `isVisitProcessed` function introduced in lsst/dax_ppdb#9.