### PR TITLE
DM-17521: Add warning when ap_pipe skips association

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -24,6 +24,7 @@
 __all__ = ["ApPipeConfig", "ApPipeTask"]
 
 import os
+import warnings
 
 import lsst.dax.ppdb as daxPpdb
 import lsst.pex.config as pexConfig
@@ -200,6 +201,13 @@ class ApPipeTask(pipeBase.CmdLineTask):
         else:
             diffImResults = self.runDiffIm(calexpRef, templateIds)
 
+        if "associator" in reuse:
+            warnings.warn(
+                "Reusing association results for some images while rerunning "
+                "others may change the associations. If exact reproducibility "
+                "matters, please clear the association database and run "
+                "ap_pipe.py with --reuse-output-from=differencer to redo all "
+                "association results consistently.")
         if "associator" in reuse and \
                 daxPpdb.isVisitProcessed(self.ppdb, calexpRef.get("calexp_visitInfo")):
             self.log.info("Association has already been run for {0}, skipping...".format(calexpRef.dataId))

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -140,6 +140,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
         self.makeSubtask("diaSourceDpddifier",
                          inputSchema=self.differencer.schema)
         self.makeSubtask("associator")
+        self.makeSubtask("diaForcedSource")
 
     @pipeBase.timeMethod
     def runDataRef(self, rawRef, templateIds=None, reuse=None):
@@ -288,10 +289,10 @@ class ApPipeTask(pipeBase.CmdLineTask):
 
         dia_sources = self.diaSourceDpddifier.run(catalog, diffim)
         result = self.associator.run(dia_sources, diffim, self.ppdb)
-        self.diaForcedSource(result.dia_objects,
-                             sensorRef.get("ccdExposureId_bits"),
-                             sensorRef.get("calexp"),
-                             diffim)
+        self.diaForcedSource.run(result.dia_objects,
+                                 sensorRef.get("ccdExposureId_bits"),
+                                 sensorRef.get("calexp"),
+                                 diffim)
 
         return pipeBase.Struct(
             l1Database=self.ppdb,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806, E266
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, E266
 # TODO: remove E266 when Task documentation is converted to rst in DM-14207
 exclude =
   bin,
@@ -12,7 +12,7 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816
   # For some reason pytest-flake8 doesn't use `exclude` consistently
   # TODO: remove E266 when Task documentation is converted to rst in DM-14207
   bin/*.py ALL

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])


### PR DESCRIPTION
This PR prints a warning (once per process) if the user includes association in the set of skippable tasks. It also does some unrelated package cleanup.