### PR TITLE
DM-16606: ap_pipe should not create DB automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ pytest_session.txt
 .pytest_cache
 .sconf_temp
 .sconsign.dblite
-bin/ap_pipe.py
+bin/*.py
 bin/*.conf
 bin/run_ap_pipe.*
 config.log

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2017-2018 University of Washington
+Copyright 2017-2019 University of Washington

--- a/bin.src/ap_pipe.py
+++ b/bin.src/ap_pipe.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 #
-# LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# This file is part of ap_pipe.
 #
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,9 +18,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 from lsst.ap.pipe import ApPipeTask

--- a/bin.src/make_ppdb.py
+++ b/bin.src/make_ppdb.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from lsst.ap.pipe.make_ppdb import makePpdb
+
+if __name__ == '__main__':
+    makePpdb()

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -64,8 +64,8 @@ The executable to run for the AP Pipeline (`ApPipeTask`) is in ``ap_pipe/bin/ap_
 To process your ingested data, run
 
 .. prompt:: bash
-   
-   ap_pipe.py repo --calib repo/calibs --rerun processed -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template templates
+
+   ap_pipe.py repo --calib repo/calibs --rerun processed -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db" --id visit=123456 ccdnum=42 filter=g --template templates
 
 In this case, a ``processed`` directory will be created within
 ``repo/rerun`` and the results will be written there.
@@ -87,7 +87,7 @@ If you prefer to have a standalone output repository, you may instead run
 
 .. prompt:: bash
 
-   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template path/to/templates
+   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db" --id visit=123456 ccdnum=42 filter=g --template path/to/templates
 
 In this case, the output directory will be created if it does not already exist.
 If you omit the ``--template`` flag, ``ap_pipe`` will assume the templates are
@@ -161,7 +161,7 @@ A full command looks like
 
 .. prompt:: bash
    
-   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c associator.level1_db.db_name=ppdb/association.db --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
+   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db" --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
 
 
 .. _section-ap-pipe-supplemental-info:

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -65,6 +65,8 @@ To process your ingested data, run
 
 .. prompt:: bash
 
+   mkdir ppdb/
+   make_ppdb.py -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db"
    ap_pipe.py repo --calib repo/calibs --rerun processed -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db" --id visit=123456 ccdnum=42 filter=g --template templates
 
 In this case, a ``processed`` directory will be created within

--- a/python/lsst/ap/pipe/make_ppdb.py
+++ b/python/lsst/ap/pipe/make_ppdb.py
@@ -1,0 +1,105 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["makePpdb"]
+
+import argparse
+
+from lsst.pipe.base import ConfigFileAction, ConfigValueAction
+from lsst.ap.association import make_dia_object_schema, make_dia_source_schema
+
+from .ap_pipe import ApPipeConfig
+
+
+class ConfigOnlyParser(argparse.ArgumentParser):
+    """Argument parser that knows standard config arguments.
+    """
+
+    def __init__(self, description=None, **kwargs):
+        if description is None:
+            description = "Create a PPDB using config overrides. At the very " \
+                "least, the overrides must define ppdb.db_url, or the final " \
+                "config will not be valid."
+
+        super().__init__(description=description, **kwargs)
+
+        self.add_argument("-c", "--config", nargs="*", action=ConfigValueAction,
+                          help="config override(s), e.g. -c foo=newfoo bar.baz=3", metavar="NAME=VALUE")
+        self.add_argument("-C", "--configfile", dest="configfile", nargs="*", action=ConfigFileAction,
+                          help="config override file(s)")
+
+    def parse_args(self, args=None, namespace=None):
+        """Parse arguments for an `ApPipeConfig`.
+
+        Parameters
+        ----------
+        args : `list` [`str`], optional
+            Argument list; if `None` then ``sys.argv`` is used.
+        namespace : `argparse.Namespace`, optional
+            An object to take the attributes. The default is a new empty
+            `~argparse.Namespace` object
+
+        Returns
+        -------
+        namespace : `argparse.Namespace`
+            A `~argparse.Namespace` instance containing fields:
+            - ``config``: the supplied config with all overrides applied,
+                validated and frozen.
+        """
+        if not namespace:
+            namespace = argparse.Namespace()
+        namespace.config = ApPipeConfig()
+
+        # ConfigFileAction and ConfigValueAction require namespace.config to exist
+        namespace = super().parse_args(args, namespace)
+        del namespace.configfile
+
+        namespace.config.validate()
+        namespace.config.freeze()
+
+        return namespace
+
+
+def makePpdb(args=None):
+    """Create a PPDB according to a config.
+
+    The command-line arguments should provide config values or a config file
+    for `ApPipeConfig`.
+
+    Parameters
+    ----------
+    args : `list` [`str`], optional
+        List of command-line arguments; if `None` use `sys.argv`.
+
+    Returns
+    -------
+    ppdb : `lsst.dax.ppdb.Ppdb`
+        The newly configured PPDB object.
+    """
+
+    parser = ConfigOnlyParser()
+    parsedCmd = parser.parse_args(args=args)
+
+    ppdb = parsedCmd.config.ppdb.apply(
+        afw_schemas=dict(DiaObject=make_dia_object_schema(),
+                         DiaSource=make_dia_source_schema()))
+    ppdb.makeSchema()
+    return ppdb

--- a/tests/test_makeppdb.py
+++ b/tests/test_makeppdb.py
@@ -1,0 +1,76 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import shlex
+import unittest
+
+import lsst.utils.tests
+from lsst.ap.pipe.make_ppdb import ConfigOnlyParser
+
+
+class MakePpdbParserTestSuite(lsst.utils.tests.TestCase):
+
+    def _parseString(self, commandLine):
+        """Tokenize and parse a command line string.
+
+        Parameters
+        ----------
+        commandLine : `str`
+            a string containing Unix-style command line arguments, but not the
+            name of the program
+
+        Returns
+        -------
+        parsed : `argparse.Namespace`
+            The parsed command line.
+        """
+        return self.parser.parse_args(shlex.split(commandLine))
+
+    def setUp(self):
+        self.parser = ConfigOnlyParser()
+
+    def testExtras(self):
+        """Verify that a command line containing extra arguments is rejected.
+        """
+        args = '-c ppdb.db_url="dummy" --id visit=42'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+    def testSetValue(self):
+        """Verify that command-line arguments get propagated.
+        """
+        args = '-c ppdb.db_url="dummy" -c ppdb.dia_object_index=pix_id_iov'
+        parsed = self._parseString(args)
+        self.assertEqual(parsed.config.ppdb.db_url, 'dummy')
+        self.assertEqual(parsed.config.ppdb.dia_object_index, 'pix_id_iov')
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR creates a `make_ppdb.py` script that takes the same config arguments as `ap_pipe.py` and only calls `Ppdb.makeSchema`, then removes the corresponding call from `ApPipeTask`*. This gives users more control over database creation and avoids certain race conditions when `ApPipeTask` is run in parallel.

*For backward-compatibility, the call from `ApPipeTask` may be reinstated and scheduled for removal on another ticket. See discussion on [`#dm-alert-prod`](https://lsstc.slack.com/messages/C2B6X08LS/).