### PR TITLE
DM-18736: Convert ap_association to use Pandas data frames (rather than afw::table) as an interface

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -300,12 +300,17 @@ class ApPipeTask(pipeBase.CmdLineTask):
         catalog = sensorRef.get(diffType + "Diff_diaSrc")
         diffim = sensorRef.get(diffType + "Diff_differenceExp")
 
-        dia_sources = self.diaSourceDpddifier.run(catalog, diffim)
+        dia_sources = self.diaSourceDpddifier.run(catalog,
+                                                  diffim,
+                                                  return_pandas=True)
         result = self.associator.run(dia_sources, diffim, self.ppdb)
-        self.diaForcedSource.run(result.dia_objects,
-                                 sensorRef.get("ccdExposureId_bits"),
-                                 sensorRef.get("calexp"),
-                                 diffim)
+        # TODO: DM-19906
+        #    Need to convert diaFourcedSource task to accept pandas.DataFrame
+        #    as an input.
+        # self.diaForcedSource.run(result.dia_objects,
+        #                          sensorRef.get("ccdExposureId_bits"),
+        #                          sensorRef.get("calexp"),
+        #                          diffim)
 
         return pipeBase.Struct(
             l1Database=self.ppdb,

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -117,7 +117,10 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
             subtasks.ccdProcessor.runDataRef.assert_called_once()
             subtasks.differencer.runDataRef.assert_called_once()
             subtasks.associator.run.assert_called_once()
-            subtasks.forcedSource.run.assert_called_once()
+            # TODO: DM-19906
+            #     Disable this test until forcedSource can be used with
+            #     pandas.
+            # subtasks.forcedSource.run.assert_called_once()
 
     def testReuseExistingOutput(self):
         """Test reuse keyword to ApPipeTask.runDataRef.
@@ -166,7 +169,10 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
             self.assertEqual(subtasks.ccdProcessor.runDataRef.call_count, 2)
             subtasks.differencer.runDataRef.assert_called_once()
             subtasks.associator.run.assert_called_once()
-            subtasks.forcedSource.run.assert_called_once()
+            # TODO: DM-19906
+            #     Disable this test until forcedSource can be used with
+            #     pandas.
+            # subtasks.forcedSource.run.assert_called_once()
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Comment out diaForcedSourceTask for now.