### PR TITLE
DM-20384: Clarify usage of make_ppdb.py script

### DIFF
--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -29,6 +29,7 @@ Using lsst.ap.pipe
    
    getting-started
    pipeline-tutorial
+   ppdb
 
 .. _lsst.ap.pipe-contributing:
 

--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -40,6 +40,14 @@ You can find Jira issues for this module under the `ap_pipe <https://jira.lsstco
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 
+Script reference
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   scripts/make_ppdb.py
+
 .. _lsst.ap.pipe-pyapi:
 
 Python API reference

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -69,8 +69,8 @@ To process your ingested data, run
    make_ppdb.py -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db"
    ap_pipe.py repo --calib repo/calibs --rerun processed -c ppdb.isolation_level=READ_UNCOMMITTED -c ppdb.db_url="sqlite:///ppdb/association.db" --id visit=123456 ccdnum=42 filter=g --template templates
 
-In this case, a ``processed`` directory will be created within
-``repo/rerun`` and the results will be written there.
+In this case, a ``processed`` directory will be created within ``repo/rerun`` and the results will be written there.
+See :doc:`ppdb` for more information on :command:`make_ppdb.py`.
 
 This example command only processes observations that have a
 :ref:`dataId<subsection-ap-pipe-previewing-dataIds>`

--- a/doc/lsst.ap.pipe/ppdb.rst
+++ b/doc/lsst.ap.pipe/ppdb.rst
@@ -1,0 +1,54 @@
+.. py:currentmodule:: lsst.ap.pipe
+
+.. program:: make_ppdb.py
+
+.. _ap-pipe-ppdb:
+
+###################################################
+Setting up the Prompt Products Database for ap_pipe
+###################################################
+
+:command:`ap_pipe.py` needs an existing Prompt Products Database (PPDB) in which to store its results.
+Such a database will be provided externally during operations, but developers can run :command:`make_ppdb.py` to set up their own database for testing.
+This page provides an overview of how to use :command:`make_ppdb.py`.
+
+.. _section-ap-pipe-ppdb-config:
+
+Configuring the database
+========================
+
+:command:`ap_pipe.py` includes information about the database location and schema in its `ApPipeConfig`, and most users pass this information to the script through the :option:`--config <ap_pipe.py --config>` and :option:`--configfile <ap_pipe.py --configfile>` command-line options.
+
+:command:`make_ppdb.py` also uses `ApPipeConfig` and the :option:`--config` and :option:`--configfile` options, so users can pass exactly the same arguments to :command:`make_ppdb.py` and :command:`ap_pipe.py`.
+Supporting identical command line arguments for both scripts makes it easy to keep the database settings in sync.
+
+For more information on the configuration options themselves, see `lsst.dax.ppdb.PpdbConfig`.
+``ppdb.db_url`` has no default and must be set to create a valid config.
+
+.. _section-ap-pipe-ppdb-examples:
+
+Examples
+========
+
+Databases can be configured using direct config overrides:
+
+.. prompt:: bash
+
+   make_ppdb.py -c ppdb.isolation_level=READ_UNCOMMITTED ppdb.db_url="sqlite:///databases/ppdb.db" differencer.coaddName=dcr
+   ap_pipe.py -c ppdb.isolation_level=READ_UNCOMMITTED ppdb.db_url="sqlite:///databases/ppdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id
+
+:command:`make_ppdb.py` ignores any `ApPipeConfig` fields not related to the PPDB (in the example, ``differencer.coaddName``), so there is no need to filter them out.
+
+Databases can also be set up using config files:
+
+.. prompt:: bash
+
+   make_ppdb.py -C myApPipeConfig.py
+   ap_pipe.py repo --calib repo/calibs --rerun myrun -C myApPipeConfig.py --id
+
+.. _section-ap-pipe-ppdb-seealso:
+
+Further reading
+===============
+
+- :doc:`pipeline-tutorial`

--- a/doc/lsst.ap.pipe/ppdb.rst
+++ b/doc/lsst.ap.pipe/ppdb.rst
@@ -8,18 +8,24 @@
 Setting up the Prompt Products Database for ap_pipe
 ###################################################
 
-:command:`ap_pipe.py` needs an existing Prompt Products Database (PPDB) in which to store its results.
-Such a database will be provided externally during operations, but developers can run :command:`make_ppdb.py` to set up their own database for testing.
-This page provides an overview of how to use :command:`make_ppdb.py`.
+.. Centralized markup for program names
+
+.. |make_ppdb| replace:: :doc:`make_ppdb.py <scripts/make_ppdb.py>`
+
+.. |ap_pipe| replace:: :command:`ap_pipe.py`
+
+|ap_pipe| needs an existing Prompt Products Database (PPDB) in which to store its results.
+Such a database will be provided externally during operations, but developers can run |make_ppdb| to set up their own database for testing.
+This page provides an overview of how to use |make_ppdb|.
 
 .. _section-ap-pipe-ppdb-config:
 
 Configuring the database
 ========================
 
-:command:`ap_pipe.py` includes information about the database location and schema in its `ApPipeConfig`, and most users pass this information to the script through the :option:`--config <ap_pipe.py --config>` and :option:`--configfile <ap_pipe.py --configfile>` command-line options.
+|ap_pipe| includes information about the database location and schema in its `ApPipeConfig`, and most users pass this information to the script through the :option:`--config <ap_pipe.py --config>` and :option:`--configfile <ap_pipe.py --configfile>` command-line options.
 
-:command:`make_ppdb.py` also uses `ApPipeConfig` and the :option:`--config` and :option:`--configfile` options, so users can pass exactly the same arguments to :command:`make_ppdb.py` and :command:`ap_pipe.py`.
+|make_ppdb| also uses `ApPipeConfig` and the :option:`--config` and :option:`--configfile` options, so users can pass exactly the same arguments to |make_ppdb| and |ap_pipe|.
 Supporting identical command line arguments for both scripts makes it easy to keep the database settings in sync.
 
 For more information on the configuration options themselves, see `lsst.dax.ppdb.PpdbConfig`.
@@ -37,7 +43,7 @@ Databases can be configured using direct config overrides:
    make_ppdb.py -c ppdb.isolation_level=READ_UNCOMMITTED ppdb.db_url="sqlite:///databases/ppdb.db" differencer.coaddName=dcr
    ap_pipe.py -c ppdb.isolation_level=READ_UNCOMMITTED ppdb.db_url="sqlite:///databases/ppdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id
 
-:command:`make_ppdb.py` ignores any `ApPipeConfig` fields not related to the PPDB (in the example, ``differencer.coaddName``), so there is no need to filter them out.
+|make_ppdb| ignores any `ApPipeConfig` fields not related to the PPDB (in the example, ``differencer.coaddName``), so there is no need to filter them out.
 
 Databases can also be set up using config files:
 

--- a/doc/lsst.ap.pipe/scripts/make_ppdb.py.rst
+++ b/doc/lsst.ap.pipe/scripts/make_ppdb.py.rst
@@ -1,0 +1,3 @@
+.. autoprogram:: lsst.ap.pipe.make_ppdb:ConfigOnlyParser()
+   :prog: make_ppdb.py
+   :groups:

--- a/python/lsst/ap/pipe/make_ppdb.py
+++ b/python/lsst/ap/pipe/make_ppdb.py
@@ -35,16 +35,25 @@ class ConfigOnlyParser(argparse.ArgumentParser):
 
     def __init__(self, description=None, **kwargs):
         if description is None:
-            description = "Create a PPDB using config overrides. At the very " \
-                "least, the overrides must define ppdb.db_url, or the final " \
-                "config will not be valid."
+            # Description must be readable in both Sphinx and make_ppdb.py -h
+            description = """\
+Create a prompt products database using config overrides for
+`lsst.ap.pipe.ApPipeConfig`.
+
+This script takes the same ``--config`` and ``--configfile`` arguments as
+command-line tasks. Calling ``ap_pipe.py`` with the same arguments uses the
+newly created database.
+
+The config overrides must define ``ppdb.db_url`` to create a valid config.
+"""
 
         super().__init__(description=description, **kwargs)
 
         self.add_argument("-c", "--config", nargs="*", action=ConfigValueAction,
-                          help="config override(s), e.g. -c foo=newfoo bar.baz=3", metavar="NAME=VALUE")
+                          help="config override(s), e.g. ``-c ppdb.prefix=fancy ppdb.db_url=\"sqlite://\"``",
+                          metavar="NAME=VALUE")
         self.add_argument("-C", "--configfile", dest="configfile", nargs="*", action=ConfigFileAction,
-                          help="config override file(s)")
+                          help="config override file(s) for ApPipeConfig")
 
     def parse_args(self, args=None, namespace=None):
         """Parse arguments for an `ApPipeConfig`.


### PR DESCRIPTION
This PR adds a script topic page on `make_ppdb.py`, as well as a short guide to using it. The guide hopefully makes it clear that `make_ppdb.py` should be configured the same as `ap_pipe.py`.