### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -209,8 +209,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
                     "matters, please clear the association database and run "
                     "ap_pipe.py with --reuse-output-from=differencer to redo all "
                     "association results consistently.")
-            if "associator" in reuse and \
-                    self.apdb.isVisitProcessed(calexpRef.get("calexp_visitInfo")):
+            if "associator" in reuse and calexpRef.datasetExists("apdb_marker", write=True):
                 message = "Association has already been run for {0}, skipping...".format(calexpRef.dataId)
                 self.log.info(message)
                 associationResults = None

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -24,7 +24,7 @@
 import contextlib
 import os
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, ANY
 
 import lsst.utils.tests
 import lsst.pex.exceptions as pexExcept
@@ -146,6 +146,11 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
         Mock guarantees that all "has this been made" tests pass,
         so skippable subtasks should actually be skipped.
         """
+        # extremely brittle because it depends on internal code of runDataRef
+        # but it only needs to work until DM-21886, then we can unit-test the subtask
+        internalRef = self.inputRef.getButler().dataRef()
+        internalRef.put.reset_mock()
+
         with self.mockPatchSubtasks(task) as subtasks:
             struct = task.runDataRef(self.inputRef, reuse=skippable)
             for subtaskName, runner in {
@@ -160,6 +165,11 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
                 else:
                     runner.assert_called_once()
                     self.assertIsNotNone(struct.getDict()[subtaskName], msg=msg)
+
+        if 'associator' in skippable:
+            internalRef.put.assert_not_called()
+        else:
+            internalRef.put.assert_called_once_with(ANY, "apdb_marker")
 
     def testCalexpRun(self):
         """Test the calexp template workflow of each ap_pipe step.

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -138,6 +138,7 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
 
         self.checkReuseExistingOutput(task, ['ccdProcessor'])
         self.checkReuseExistingOutput(task, ['ccdProcessor', 'differencer'])
+        self.checkReuseExistingOutput(task, ['ccdProcessor', 'differencer', 'associator'])
 
     def checkReuseExistingOutput(self, task, skippable):
         """Check whether a task's subtasks are skipped when "reuse" is set.


### PR DESCRIPTION
This PR writes an `apdb_marker` dataset (introduced in lsst/obs_base#182) to the repository once association and forced photometry finish (successfully or not). It also uses the new dataset to streamline completion checking, and makes some improvements to the relevant unit tests.

This code will need to be updated once [DM-22039](https://jira.lsstcorp.org/browse/DM-22039) merges.