### PR TITLE
DM-22478: Lightly restructure ap_association tasks and create new DiaObject/DiaSource pre-loading task.

### DIFF
--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -109,12 +109,14 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
         """
         with patch.object(task, "ccdProcessor") as mockCcdProcessor, \
                 patch.object(task, "differencer") as mockDifferencer, \
+                patch.object(task, "diaCatalogLoader") as mockDiaCatLoader, \
                 patch.object(task, "diaSourceDpddifier") as mockDpddifier, \
                 patch.object(task, "associator") as mockAssociator, \
                 patch.object(task, "diaForcedSource") as mockForcedSource, \
                 patch.object(task, "apdb") as mockApdb:
             yield pipeBase.Struct(ccdProcessor=mockCcdProcessor,
                                   differencer=mockDifferencer,
+                                  diaCatalogLoader=mockDiaCatLoader,
                                   dpddifier=mockDpddifier,
                                   associator=mockAssociator,
                                   diaForcedSource=mockForcedSource,


### PR DESCRIPTION
Modify runAssociation for new method inputs.

Fix bug in runAssociation

Add validation test for HTM level.

Debug validation.