### PR TITLE
DM-24259: Create “stub“ Gen2 HSC dataset for CI testing

### DIFF
--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -83,7 +83,7 @@ The config overrides must define ``apdb.db_url`` to create a valid config.
         del namespace.configfile
 
         namespace.config.validate()
-        namespace.config.freeze()
+        # Do not freeze the config, as a workaround for DM-24435.
 
         return namespace
 


### PR DESCRIPTION
This PR adds a workaround for [DM-24435](https://jira.lsstcorp.org/browse/DM-24435), which otherwise causes `ap_verify` to crash when run with standard HSC configs.

This PR may not need to be merged; see lsst/pex_config#55.