### PR TITLE
DM-21939: Create Gen 3 AP Pipeline

### DIFF
--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -14,8 +14,10 @@ Setting up the Alert Production Database for ap_pipe
 
 .. |ap_pipe| replace:: :command:`ap_pipe.py`
 
+.. |pipetask| replace:: :command:`pipetask`
 
-In its default configuration, the Alert Production Pipeline, as represented by :lsst-task:`lsst.ap.pipe.ApPipeTask` and executed by |ap_pipe|, relies on a database to save and load DIASources and DIAObjects.
+
+In its default configuration, the Alert Production Pipeline, as represented by :lsst-task:`lsst.ap.pipe.ApPipeTask` (Gen 2) or :file:`pipelines/ApPipe.yaml` (Gen 3), relies on a database to save and load DIASources and DIAObjects.
 When running as part of the operational system, this database will be provided externally.
 However, during testing and development, developers can run |make_apdb| to set up their own database.
 This page provides an overview of how to use |make_apdb|.
@@ -30,6 +32,9 @@ The database is configured using `~lsst.dax.apdb.ApdbConfig`.
 |make_apdb| also uses `ApPipeConfig` and the :option:`--config` and :option:`--configfile` options, so users can pass exactly the same arguments to |make_apdb| and |ap_pipe|.
 Supporting identical command line arguments for both scripts makes it easy to keep the database settings in sync.
 
+For |pipetask| users the process is almost the same, except that |pipetask|'s config syntax is not exactly the same.
+The :option:`--config <pipetask --config>` and :option:`--configfile <pipetask --configfile>` options for |pipetask| use colons as separators between each task and its config; replace these with periods for |make_apdb|.
+
 Note that ``apdb.db_url`` has no default; a value *must* be provided by the user.
 
 .. _section-ap-pipe-apdb-examples:
@@ -37,21 +42,28 @@ Note that ``apdb.db_url`` has no default; a value *must* be provided by the user
 Examples
 ========
 
-Databases can be configured using direct config overrides:
+Databases can be configured using direct config overrides (see :ref:`pipeline-tutorial-gen2` for an explanation of the |ap_pipe| command line):
 
 .. prompt:: bash
 
    make_apdb.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr
-   ap_pipe.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id
+   ap_pipe.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id [optional IDs to process]
 
 |make_apdb| ignores any `ApPipeConfig` fields not related to the APDB (in the example, ``differencer.coaddName``), so there is no need to filter them out.
+
+In Gen 3, this becomes (see :ref:`ap-pipe-pipeline-tutorial` for an explanation of |pipetask|):
+
+.. prompt:: bash
+
+   make_apdb.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr
+   pipetask run -p ApPipe.yaml -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED diaPipe:apdb.db_url="sqlite:///databases/apdb.db" differencer:coaddName=dcr -b repo -o myrun
 
 Databases can also be set up using config files:
 
 .. prompt:: bash
 
    make_apdb.py -C myApPipeConfig.py
-   ap_pipe.py repo --calib repo/calibs --rerun myrun -C myApPipeConfig.py --id
+   ap_pipe.py repo --calib repo/calibs --rerun myrun -C myApPipeConfig.py --id [optional ID to process]
 
 .. _section-ap-pipe-apdb-seealso:
 
@@ -59,3 +71,4 @@ Further reading
 ===============
 
 - :doc:`pipeline-tutorial-gen2`
+- :doc:`pipeline-tutorial`

--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -58,4 +58,4 @@ Databases can also be set up using config files:
 Further reading
 ===============
 
-- :doc:`pipeline-tutorial`
+- :doc:`pipeline-tutorial-gen2`

--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -42,7 +42,7 @@ Note that ``apdb.db_url`` has no default; a value *must* be provided by the user
 Examples
 ========
 
-Databases can be configured using direct config overrides (see :ref:`pipeline-tutorial-gen2` for an explanation of the |ap_pipe| command line):
+Databases can be configured using direct config overrides (see :ref:`ap-pipe-pipeline-tutorial-gen2` for an explanation of the |ap_pipe| command line):
 
 .. prompt:: bash
 

--- a/doc/lsst.ap.pipe/getting-started-gen2.rst
+++ b/doc/lsst.ap.pipe/getting-started-gen2.rst
@@ -7,6 +7,12 @@ Getting started with the AP pipeline (Gen 2)
 ############################################
 
 
+This page explains how to set up a Gen 2 data repository that can then be processed with the AP Pipeline (see :doc:`pipeline-tutorial-gen2`).
+This is the established Science Pipelines workflow, and is compatible with a variety of existing pipelines and tools.
+However, it is expected to be phased out in the future in favor of the Gen 3 framework.
+
+If you already have a Gen 3 data repository or want to learn the new framework, see :doc:`getting-started`.
+
 .. _section-ap-pipe-installation-gen2:
 
 Installation

--- a/doc/lsst.ap.pipe/getting-started-gen2.rst
+++ b/doc/lsst.ap.pipe/getting-started-gen2.rst
@@ -34,23 +34,16 @@ is available in :ref:`ap_verify <ap-verify-run-ingest>`. However, this works
 only on datasets which adhere to the :doc:`ap_verify dataset </modules/lsst.ap.verify/datasets>` format.
 Alternately, you may use a pre-
 ingested dataset or manually ingest files yourself following the directions
-for a given ``obs_`` package, e.g.,
-step 4 of `the obs_decam README <https://github.com/lsst/obs_decam/blob/master/README.md>`_.
+for a given ``obs_`` package.
 
 A standard ingestion workflow for DECam looks something like
 
 .. prompt:: bash
 
-   ingestImagesDecam.py input_loc --filetype raw path/to/raw/files
-   ingestCalibs.py input_loc --calib calib_loc path/to/flats/and/biases --validity 999
-   ingestCalibs.py input_loc --calib calib_loc --calibType defect --mode=skip path/to/defects --validity 0
-
-.. note::
-
-   Defect ingestion is a step unique to DECam. It presently requires
-   ``--mode=skip``, this mode interprets paths as relative to ``calib_loc``,
-   and the validity value is not used (but must be included). This interface
-   may change when `DM-5467 <https://jira.lsstcorp.org/browse/DM-5467>`_ is completed.
+   ingestImagesDecam.py input_loc --filetype raw path/to/raw/files --mode=link
+   ingestCuratedCalibs.py input_loc --calib calib_loc $OBS_DECAM_DATA_DIR/decam/defects
+   ingestCuratedCalibs.py input_loc --calib calib_loc $OBS_DECAM_DATA_DIR/decam/crosstalk
+   ingestCalibs.py input_loc --calib calib_loc /path/to/biases/and/flats --mode=link --validity 999
 
 
 .. _section-ap-pipe-required-data-products-gen2:
@@ -69,13 +62,13 @@ For the AP Pipeline to successfully process data, the following is required:
     We recommend using Pan-STARRS for photometry and Gaia for astrometry.
     An example :ref:`config file <command-line-task-config-howto-configfile>` for using these two catalogs can be found in the `ap_verify_hits2015`_ repository.
 
-- **Calibration products** (biases, flats, and defects, if applicable)
-  ingested into a Butler repository you must specify with the ``--calib`` flag on
+- **Calibration products** (biases, flats, and possibly others)
+  ingested into a Butler repository that you must specify with the ``--calib`` flag on
   the command line at runtime
 
   - To check if this requirement has been satisfied, you can inspect the
     :file:`calibRegistry.sqlite3` created in this repository and ensure the information
-    in the flat, bias, and defect tables is accurate
+    in the tables is accurate
 
 - **Template images** (of type ``deepCoadd`` by default) for difference imaging
   must be either in the main Butler repository or in another location you may
@@ -89,7 +82,7 @@ A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/
 that works with ``ap_pipe`` in the :doc:`/modules/lsst.ap.verify/datasets` format
 is available as `ap_verify_hits2015`_. However, this dataset must be
 ingested as described in :ref:`section-ap-pipe-ingesting-data-files-gen2`, and the reference
-catalog and defect files must be decompressed and extracted.
+catalog files must be decompressed and extracted.
 
 Please continue to :doc:`Pipeline Tutorial <pipeline-tutorial-gen2>` for more
 details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/getting-started-gen2.rst
+++ b/doc/lsst.ap.pipe/getting-started-gen2.rst
@@ -1,13 +1,13 @@
 .. py:currentmodule:: lsst.ap.pipe
 
-.. _ap-pipe-getting-started:
+.. _ap-pipe-getting-started-gen2:
 
-####################################
-Getting started with the AP pipeline
-####################################
+############################################
+Getting started with the AP pipeline (Gen 2)
+############################################
 
 
-.. _section-ap-pipe-installation:
+.. _section-ap-pipe-installation-gen2:
 
 Installation
 ============
@@ -16,7 +16,7 @@ Installation
 It is installed as part of the ``lsst_apps`` and ``lsst_distrib`` metapackages.
 
 
-.. _section-ap-pipe-ingesting-data-files:
+.. _section-ap-pipe-ingesting-data-files-gen2:
 
 Ingesting data files
 ====================
@@ -53,7 +53,7 @@ A standard ingestion workflow for DECam looks something like
    may change when `DM-5467 <https://jira.lsstcorp.org/browse/DM-5467>`_ is completed.
 
 
-.. _section-ap-pipe-required-data-products:
+.. _section-ap-pipe-required-data-products-gen2:
 
 Required data products
 ======================
@@ -88,8 +88,8 @@ For the AP Pipeline to successfully process data, the following is required:
 A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ 
 that works with ``ap_pipe`` in the :doc:`/modules/lsst.ap.verify/datasets` format
 is available as `ap_verify_hits2015`_. However, this dataset must be
-ingested as described in :ref:`section-ap-pipe-ingesting-data-files`, and the reference
+ingested as described in :ref:`section-ap-pipe-ingesting-data-files-gen2`, and the reference
 catalog and defect files must be decompressed and extracted.
 
-Please continue to :doc:`Pipeline Tutorial <pipeline-tutorial>` for more
+Please continue to :doc:`Pipeline Tutorial <pipeline-tutorial-gen2>` for more
 details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -1,0 +1,58 @@
+.. py:currentmodule:: lsst.ap.pipe
+
+.. _ap-pipe-getting-started:
+
+.. _ap-pipe-getting-started-gen3:
+
+############################################
+Getting started with the AP pipeline (Gen 3)
+############################################
+
+
+.. _section-ap-pipe-installation:
+
+Installation
+============
+
+:doc:`lsst.ap.pipe <index>` is available from the `LSST Science Pipelines <https://pipelines.lsst.io/>`_.
+It is installed as part of the ``lsst_distrib`` metapackage, which also includes infrastructure for running the pipeline from the command line.
+
+
+.. _section-ap-pipe-ingesting-data-files:
+
+Ingesting data files
+====================
+
+Vera Rubin Observatory-style image processing typically operates on Butler repositories and does not directly interface with data files.
+:doc:`lsst.ap.pipe <index>` is no exception.
+The process of turning a set of raw data files and corresponding calibration products into a format the Butler understands is called ingestion.
+Ingestion for the Generation 3 Butler is still being developed, and is outside the scope of the AP Pipeline.
+
+.. TODO: fill in details once we know what happens with image-like calibs
+
+
+.. _section-ap-pipe-required-data-products:
+
+Required data products
+======================
+
+For the AP Pipeline to successfully process data, the following must be present in a Butler repository:
+
+- **Raw science images** to be processed.
+
+- **Reference catalogs** covering at least the area of the raw images.
+  We recommend using Pan-STARRS for photometry and Gaia for astrometry.
+
+- **Calibration products** (biases, flats, and possibly others, depending on the instrument)
+
+- **Template images** for difference imaging.
+  These are of type ``deepCoadd`` by default, but the AP pipeline can be configured to use other types.
+
+.. TODO: update default for DM-14601
+
+.. _ap_verify_hits2015: https://github.com/lsst/ap_verify_hits2015/
+
+A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ that works with ``ap_pipe`` in the :doc:`/modules/lsst.ap.verify/datasets` format is available as `ap_verify_hits2015`_.
+However, raw images from this dataset must be ingested.
+
+Please continue to :doc:`the Pipeline Tutorial <pipeline-tutorial>` for more details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -8,6 +8,11 @@
 Getting started with the AP pipeline (Gen 3)
 ############################################
 
+This page explains how to set up a Gen 3 data repository that can then be processed with the AP Pipeline (see :doc:`pipeline-tutorial`).
+This is appropriate if you are trying to learn the new workflow, and compatibility or integration with other tools is not a problem.
+The Gen 3 processing is still being finalized, and all details in these tutorials are subject to change.
+
+If you already have a Gen 2 data repository or need compatibility with existing code, see :doc:`getting-started-gen2`.
 
 .. _section-ap-pipe-installation:
 

--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -19,16 +19,30 @@ Overview
 
    pipeline-overview
 
-.. .. _lsst.ap.pipe-using:
+.. _lsst.ap.pipe-using-gen2:
 
-Using lsst.ap.pipe
-==================
+Using lsst.ap.pipe in Gen 2
+===========================
 
 .. toctree::
    :maxdepth: 1
 
    getting-started-gen2
    pipeline-tutorial-gen2
+   apdb
+
+.. _lsst.ap.pipe-using:
+
+.. _lsst.ap.pipe-using-gen3:
+
+Using lsst.ap.pipe in Gen 3
+===========================
+
+.. toctree::
+   :maxdepth: 1
+
+   getting-started
+   pipeline-tutorial
    apdb
 
 .. _lsst.ap.pipe-contributing:

--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -27,8 +27,8 @@ Using lsst.ap.pipe
 .. toctree::
    :maxdepth: 1
 
-   getting-started
-   pipeline-tutorial
+   getting-started-gen2
+   pipeline-tutorial-gen2
    apdb
 
 .. _lsst.ap.pipe-contributing:

--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -8,8 +8,17 @@ lsst.ap.pipe
 
 .. Paragraph that describes what this Python module does and links to related modules and frameworks.
 
-The ``lsst.ap.pipe`` module links together a set of common image processing tasks so that a user may run one Command-Line Task on a dataset of raw, ingested images rather than several.
-The Alert Production (AP) pipeline includes three key data processing Tasks for LSST Prompt Data Products: `~lsst.pipe.tasks.ProcessCcdTask` (which includes `~lsst.ip.isr.IsrTask`),  `~lsst.ip.diffim.ImageDifferenceTask`, and `~lsst.ap.associate.AssociationTask`.
+The ``lsst.ap.pipe`` module links together a set of common image processing tasks so that a user may run one command on a dataset of raw, ingested images rather than several.
+The Alert Production (AP) pipeline includes the following key data processing Tasks for LSST Prompt Data Products: `~lsst.ip.isr.IsrTask`, `~lsst.pipe.tasks.characterizeImage.CharacterizeImageTask`, `~lsst.pipe.tasks.calibrate.CalibrateTask`, `~lsst.pipe.tasks.imageDifference.ImageDifferenceTask`, and `~lsst.ap.association.DiaPipelineTask`.
+
+At present, the alert production pipeline is implemented using two separate frameworks that store and retrieve data from "Butler" repositories in incompatible ways:
+
+- `ApPipeTask` is an `lsst.pipe.base.CmdLineTask` that reads and writes data using the :ref:`lsst.daf.persistence` package.
+  This is the established "Gen 2" framework.
+- ``ApPipe`` is an `lsst.pipe.base.Pipeline` that reads and writes data using the :ref:`lsst.daf.butler` package.
+  This "Gen 3" framework is expected to be the only implementation in the future.
+
+.. TODO: add links to Gen 3 docs as they become available
 
 Overview
 ========

--- a/doc/lsst.ap.pipe/pipeline-overview.rst
+++ b/doc/lsst.ap.pipe/pipeline-overview.rst
@@ -7,22 +7,22 @@ Overview of the AP pipeline
 ###########################
 
 :doc:`lsst.ap.pipe <index>` is a data processing pipeline for Prompt Data Products.
-It is a Command-Line Task which operates on ingested raw data in a Butler repository.
+It operates on ingested raw data in a Butler repository.
 It also requires appropriate calibration products and templates. As it runs,
-`ApPipeTask` generates calibrated exposures, difference images,
+the pipeline generates calibrated exposures, difference images,
 difference image source catalogs, and a source association database.
 
 The initial motivation for :doc:`lsst.ap.pipe <index>`, information about one of the original test datasets,
 and an outdated tutorial are available in `DMTN-039 <https://dmtn-039.lsst.io>`_.
 
-The AP Pipeline calls three main tasks and their associated subtasks:
+The AP Pipeline calls several main tasks and their associated subtasks:
 
-1. `~lsst.pipe.tasks.ProcessCcdTask`, which in turn calls `lsst.ip.isr.IsrTask`,
-   `lsst.pipe.tasks.CharacterizeImageTask`, and `lsst.pipe.tasks.CalibrateTask`
-   to perform image reduction as well as photometric and astrometric calibration;
-2. `~lsst.pipe.tasks.ImageDifferenceTask`, which uses many utilities from
+#. `~lsst.ip.isr.IsrTask`, which performs image reduction;
+#. `~lsst.pipe.tasks.characterizeImage.CharacterizeImageTask`, which estimates the background and point-spread function of an image;
+#. `~lsst.pipe.tasks.calibrate.CalibrateTask`, which performs photometric and astrometric calibration;
+#. `~lsst.pipe.tasks.imageDifference.ImageDifferenceTask`, which uses many utilities from
    :doc:`lsst.ip.diffim </modules/lsst.ip.diffim/index>`; and
-3. `~lsst.ap.associate.AssociationTask`, which makes a catalog of
+#. `~lsst.ap.association.DiaPipelineTask`, which makes a catalog of
    Difference Image Analysis (DIA) Objects from the DIASources created
    during image differencing.
 
@@ -32,7 +32,7 @@ to verify the output.
 
 :doc:`ap_pipe <index>` is entirely written in Python. Key contents include:
 
-- `ApPipeTask`: a `~lsst.pipe.base.CmdLineTask` for running the entire AP Pipeline
+- `ApPipeTask`: a `~lsst.pipe.base.CmdLineTask` for running the entire AP Pipeline in the older, "Gen 2" data processing framework
 - `ApPipeConfig`: a config for customizing ``ApPipeTask`` for a particular dataset's needs.
   Supported observatory packages should provide a :ref:`config override file <command-line-task-config-howto-obs>` that does most of the work.
-
+- :file:`ApPipe.yaml`: a `~lsst.pipe.base.Pipeline` configuration for running the entire AP Pipeline in the newer, "Gen 3" framework

--- a/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
@@ -1,6 +1,6 @@
 .. py:currentmodule:: lsst.ap.pipe
 
-.. _pipeline-tutorial-gen2:
+.. _ap-pipe-pipeline-tutorial-gen2:
 
 ###############################
 Running the AP pipeline (Gen 2)

--- a/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
@@ -1,15 +1,15 @@
 .. py:currentmodule:: lsst.ap.pipe
 
-.. _pipeline-tutorial:
+.. _pipeline-tutorial-gen2:
 
-#######################
-Running the AP pipeline
-#######################
+###############################
+Running the AP pipeline (Gen 2)
+###############################
 
 Setup
 =====
 
-Pick up where you left off in :doc:`Getting Started <getting-started>`.
+Pick up where you left off in :doc:`Getting Started <getting-started-gen2>`.
 This means you already have a repository of ingested DECam data and have setup
 the LSST Science Pipelines stack as well as ``ap_pipe`` and ``ap_association``.
 
@@ -54,7 +54,7 @@ Your directory structure should look something like
                   psfMatched-0,1.fits
                   ...
 
-.. _section-ap-pipe-command-line:
+.. _section-ap-pipe-command-line-gen2:
 
 AP pipeline on the command line
 ===============================
@@ -73,7 +73,7 @@ In this case, a ``processed`` directory will be created within ``repo/rerun`` an
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
 
 This example command only processes observations that have a
-:ref:`dataId<subsection-ap-pipe-previewing-dataIds>`
+:ref:`dataId<subsection-ap-pipe-previewing-dataIds-gen2>`
 corresponding to visit 123456 and ccdnum 42 in with a filter called g.
 
 :doc:`lsst.ap.pipe <index>` supports ``dataId`` parsing, e.g., ``ccdnum=3^6..12`` will process
@@ -101,7 +101,7 @@ somewhere in ``repo``.
    The location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
    In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
 
-.. _section-ap-pipe-expected-outputs:
+.. _section-ap-pipe-expected-outputs-gen2:
 
 Expected outputs
 ================
@@ -139,7 +139,7 @@ For example, in python
    diaSourceTable = butler.get('deepDiff_diaSrc', dataId=dataId)
 
 
-.. _section-ap-pipe-calexp-templates:
+.. _section-ap-pipe-calexp-templates-gen2:
 
 Calexp template mode
 ====================
@@ -166,12 +166,12 @@ A full command looks like
    ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
 
 
-.. _section-ap-pipe-supplemental-info:
+.. _section-ap-pipe-supplemental-info-gen2:
 
 Supplemental information
 ========================
 
-.. _subsection-ap-pipe-previewing-dataIds:
+.. _subsection-ap-pipe-previewing-dataIds-gen2:
 
 Previewing dataIds
 ------------------
@@ -193,9 +193,9 @@ Running on other cameras
 ------------------------
 
 Running ap_pipe on cameras other than DECam works much the same way: you need to provide a raw repo and either a rerun or an output repo, and you may need to provide calib or template repos.
-The :ref:`calexp configuration file <section-ap-pipe-calexp-templates>` will work with any camera.
+The :ref:`calexp configuration file <section-ap-pipe-calexp-templates-gen2>` will work with any camera.
 
-You will need to use a dataId formatted appropriately for the camera; check the camera's obs package documentation or consult the :ref:`--show data<subsection-ap-pipe-previewing-dataIds>` flag.
+You will need to use a dataId formatted appropriately for the camera; check the camera's obs package documentation or consult the :ref:`--show data<subsection-ap-pipe-previewing-dataIds-gen2>` flag.
 
 Common errors
 -------------
@@ -206,7 +206,7 @@ Common errors
   cannot be accessed.
 
 
-.. _section-ap-pipe-interpreting-results:
+.. _section-ap-pipe-interpreting-results-gen2:
 
 Interpreting the results
 ========================

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -1,0 +1,116 @@
+.. py:currentmodule:: lsst.ap.pipe
+
+.. _ap-pipe-pipeline-tutorial:
+
+.. _ap-pipe-pipeline-tutorial-gen3:
+
+###############################
+Running the AP pipeline (Gen 3)
+###############################
+
+Setup
+=====
+
+Pick up where you left off in :doc:`Getting Started <getting-started>`.
+This means you already have a repository of ingested DECam data and have set up the LSST Science Pipelines stack.
+
+Your repository should have the following collections, which can be checked using ``butler query-collections <repo>``:
+
+- **DECam/calib**: biases, flats, defects, camera specs, etc.
+- **DECam/raw/all**: images to be processesd
+- **refcats**: reference catalogs for calibration
+- **skymaps**: index for the templates
+- **templates/deep**: ``deepCoadd`` templates for difference imaging
+
+
+.. _section-ap-pipe-command-line:
+
+AP pipeline on the command line
+===============================
+
+Like most Vera Rubin Observatory pipelines, the AP Pipeline is run with an external runner called ``pipetask``.
+This can be found in the ``ctrl_mpexec`` package, which is included as part of ``lsst_distrib``.
+
+The pipeline itself is configured in `ap_pipe/pipelines/ApPipe.yaml <https://github.com/lsst/ap_pipe/blob/master/pipelines/ApPipe.yaml>`_.
+
+To process your ingested data, run
+
+.. prompt:: bash
+
+   mkdir apdb/
+   make_apdb.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" -o processed -d "visit in (123456, 123457) and detector=42"
+
+In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
+See :doc:`apdb` for more information on :command:`make_apdb.py`.
+
+This example command only processes observations corresponding to visits 123456 and 123457, both with only detector 42 (the Gen 2 terms "ccd" and "ccdnum" are no longer used).
+
+The example creates a "chained" output collection that can refer back to its inputs.
+If you prefer to have a standalone output collection, you may instead run
+
+.. prompt:: bash
+
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" --output-run processed -d "visit in (123456, 123457) and detector=42"
+
+.. note::
+
+   If you are using the default (SQLite) association database, you must :doc:`configure </modules/lsst.pipe.base/command-line-task-config-howto>` the database location, or ``ap_pipe`` will not run.
+   The location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
+   In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
+
+.. note::
+
+   Both examples above are only valid when running the pipeline for the first time.
+   When rerunning with an existing chained collection using ``-o``, you must omit the ``-i`` argument.
+   When rerunning with an existing standalone collection using ``--output-run``, you must pass ``--extend-run``.
+
+.. _section-ap-pipe-expected-outputs:
+
+Expected outputs
+================
+
+If you used the chained option above, most of the output from ``ap_pipe`` should be written to a timestamped collection (e.g., ``processed/20200131T00h00m00s``) in the repository.
+The exception is the source association database, which will be written to the location you configure.
+The result from running ``ap_pipe`` should look something like
+
+.. code-block:: none
+
+   apdb/
+      association.db   <--- the Alert Production Database with DIAObjects
+   repo/
+      contains_no_user_servicable_files/
+
+To inspect this data with the Butler, you should instantiate a Butler within python and access the data products that way.
+
+For example, in python
+
+.. code-block:: python
+
+   import lsst.daf.butler as dafButler
+   butler = dafButler.Butler('repo', collections="processed")  # collections keyword is optional
+   dataId = {'instrument': 'DECam', 'visit': 123456, 'detector': 42}
+   calexp = butler.get('calexp', dataId=dataId)
+   diffim = butler.get('deepDiff_differenceExp', dataId=dataId)
+   diaSourceTable = butler.get('deepDiff_diaSrc', dataId=dataId)
+
+
+.. _section-ap-pipe-supplemental-info:
+
+Supplemental information
+========================
+
+Running on other cameras
+------------------------
+
+Running ap_pipe on cameras other than DECam works much the same way:.
+You need to provide a repository containing raws, calibs, and templates appropriate for the camera.
+
+Common errors
+-------------
+
+.. TODO: update (or remove!) after DM-25013
+
+* 'KeyError: DatasetType <type> could not be found': This usually means you left out the ``--register-dataset-types`` argument.
+* 'Expected exactly one instance of input <arbitrary dataset>': This may mean an invalid pipeline, but can also mean that you did not provide an ``-i`` or ``--input`` argument when it was required.
+  This is especially likely if the data ID is not one of the expected values.

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -1,0 +1,21 @@
+# Gen 3 pipeline for Alert Production
+
+description: End to end AP pipeline
+inherits:
+  - location: $PIPE_TASKS_DIR/pipelines/ProcessCcd.yaml
+tasks:
+    differencer:
+        class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+        config:
+            # Always prefer decorrelation; may eventually become ImageDifferenceTask default
+            doDecorrelation: True
+            detection.thresholdValue: 5.0  # needed with doDecorrelation
+            # Don't have source catalogs for templates
+            doSelectSources: False
+    diaPipe:
+        class: lsst.ap.association.DiaPipelineTask
+contracts:
+    # DiaPipelineTask needs diaSource fluxes, catalogs, and difference exposures
+    - differencer.doMeasurement is True
+    - differencer.doWriteSources is True
+    - differencer.doWriteSubtractedExp is True

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -19,3 +19,6 @@ contracts:
     - differencer.doMeasurement is True
     - differencer.doWriteSources is True
     - differencer.doWriteSubtractedExp is True
+    # Inputs and outputs must match
+    - differencer.connections.coaddName == diaPipe.connections.coaddName
+    - differencer.connections.fakesType == diaPipe.connections.fakesType

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -67,6 +67,8 @@ class ApPipeConfig(pexConfig.Config):
 
     def validate(self):
         pexConfig.Config.validate(self)
+        if not self.ccdProcessor.calibrate.doWrite or not self.ccdProcessor.calibrate.doWriteExposure:
+            raise ValueError("Differencing needs calexps [ccdProcessor.calibrate.doWrite, doWriteExposure]")
         if not self.differencer.doMeasurement:
             raise ValueError("Source association needs diaSource fluxes [differencer.doMeasurement].")
         if not self.differencer.doWriteSources:

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -104,7 +104,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
 
         self.makeSubtask("ccdProcessor", butler=butler)
         self.makeSubtask("differencer", butler=butler)
-        self.makeSubtask("diaPipe", initInputs={"diaSourceSchema": self.differencer.schema})
+        self.makeSubtask("diaPipe", initInputs={"diaSourceSchema": self.differencer.outputSchema})
 
     @pipeBase.timeMethod
     def runDataRef(self, rawRef, templateIds=None, reuse=None):

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -268,7 +268,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
 
         # apdb_marker triggers metrics processing; let them try to read
         # something even if association failed
-        sensorRef.put(results.apdb_marker, "apdb_marker")
+        sensorRef.put(results.apdbMarker, "apdb_marker")
 
         return pipeBase.Struct(
             l1Database=self.diaPipe.apdb,


### PR DESCRIPTION
This PR makes some code changes to conform to lsst/ap_association#86, and adds a pipeline config file to the repository (we may later want to move it to `pipe_tasks`, but I think doing so at this point would be confusing). For readability, I've put the documentation in different commits from the changes they document.

I've moved the old documentation to "Gen 2" files and created a modified "Gen 3" copy under the original filenames. GitHub displays this as an in-place change; I'm not sure whether it will be easier to review the changes that way, or as a completely new document.