### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -4,7 +4,7 @@ description: End to end AP pipeline
 inherits:
   - location: $PIPE_TASKS_DIR/pipelines/ProcessCcd.yaml
 tasks:
-    differencer:
+    imageDifference:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
         config:
             # Always prefer decorrelation; may eventually become ImageDifferenceTask default
@@ -16,9 +16,9 @@ tasks:
         class: lsst.ap.association.DiaPipelineTask
 contracts:
     # DiaPipelineTask needs diaSource fluxes, catalogs, and difference exposures
-    - differencer.doMeasurement is True
-    - differencer.doWriteSources is True
-    - differencer.doWriteSubtractedExp is True
+    - imageDifference.doMeasurement is True
+    - imageDifference.doWriteSources is True
+    - imageDifference.doWriteSubtractedExp is True
     # Inputs and outputs must match
-    - differencer.connections.coaddName == diaPipe.connections.coaddName
-    - differencer.connections.fakesType == diaPipe.connections.fakesType
+    - imageDifference.connections.coaddName == diaPipe.connections.coaddName
+    - imageDifference.connections.fakesType == diaPipe.connections.fakesType

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -269,7 +269,7 @@ class ApPipeTask(pipeBase.CmdLineTask):
             diaSourceCat=sensorRef.get(diffType + "Diff_diaSrc"),
             diffIm=sensorRef.get(diffType + "Diff_differenceExp"),
             exposure=sensorRef.get("calexp"),
-            template=sensorRef.get(diffType + "Diff_warpedExp"),
+            warpedExposure=sensorRef.get(diffType + "Diff_warpedExp"),
             ccdExposureIdBits=sensorRef.get("ccdExposureId_bits"))
 
         # apdb_marker triggers metrics processing; let them try to read


### PR DESCRIPTION
This PR modifies a call to `DiaPipelineTask` (in response to lsst/ap_association#97). It also changes the AP pipeline's Gen 3 name for image differencing to match its default name, which makes it much easier to configure generic metric pipelines that depend on `ImageDifferenceTask`.