### PR TITLE
DM-22663: Reimplement make_apdb.py for Gen 3

### DIFF
--- a/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
@@ -67,7 +67,7 @@ To process your ingested data, run
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db"
+   make_apdb.py -c isolation_level=READ_UNCOMMITTED -c db_url="sqlite:///apdb/association.db"
    ap_pipe.py repo --calib repo/calibs --rerun processed -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456^123457 ccdnum=42 filter=g --template templates
 
 In this case, a ``processed`` directory will be created within ``repo/rerun`` and the results will be written there.

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -38,7 +38,7 @@ To process your ingested data, run
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db"
+   make_apdb.py -c isolation_level=READ_UNCOMMITTED -c db_url="sqlite:///apdb/association.db"
    pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" -o processed -d "visit in (123456, 123457) and detector=42"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -23,9 +23,9 @@ __all__ = ["makeApdb"]
 
 import argparse
 
-from lsst.dax.apdb import ApdbConfig, Apdb
+from lsst.dax.apdb import Apdb
 from lsst.pipe.base.configOverrides import ConfigOverrides
-from lsst.ap.association import make_dia_object_schema, make_dia_source_schema
+from lsst.ap.association import DiaPipelineConfig, make_dia_object_schema, make_dia_source_schema
 
 
 class ConfigOnlyParser(argparse.ArgumentParser):
@@ -79,7 +79,8 @@ The config overrides must define ``db_url`` to create a valid config.
         # ConfigFileAction and ConfigValueAction require namespace.overrides to exist
         namespace = super().parse_args(args, namespace)
         del namespace.configfile
-        namespace.config = ApdbConfig()
+        # Make ApdbConfig as a subconfig of DiaPipelineConfig to ensure correct defaults get set
+        namespace.config = DiaPipelineConfig().apdb.value
         try:
             namespace.overrides.applyTo(namespace.config)
         except Exception as e:  # yes, configs really can raise anything

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -83,7 +83,7 @@ The config overrides must define ``apdb.db_url`` to create a valid config.
         del namespace.configfile
 
         namespace.config.validate()
-        # Do not freeze the config, as a workaround for DM-24435.
+        namespace.config.freeze()
 
         return namespace
 

--- a/tests/test_makeapdb.py
+++ b/tests/test_makeapdb.py
@@ -50,31 +50,31 @@ class MakeApdbParserTestSuite(lsst.utils.tests.TestCase):
     def testExtras(self):
         """Verify that a command line containing extra arguments is rejected.
         """
-        args = '-c diaPipe.apdb.db_url="dummy" --id visit=42'
+        args = '-c db_url="dummy" --id visit=42'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
     def testSetValue(self):
         """Verify that command-line arguments get propagated.
         """
-        args = '-c diaPipe.apdb.db_url="dummy" -c diaPipe.apdb.dia_object_index=pix_id_iov'
+        args = '-c db_url="dummy" -c dia_object_index=pix_id_iov'
         parsed = self._parseString(args)
-        self.assertEqual(parsed.config.diaPipe.apdb.db_url, 'dummy')
-        self.assertEqual(parsed.config.diaPipe.apdb.dia_object_index, 'pix_id_iov')
+        self.assertEqual(parsed.config.db_url, 'dummy')
+        self.assertEqual(parsed.config.dia_object_index, 'pix_id_iov')
 
     def testSetValueFile(self):
         """Verify that config files are handled correctly.
         """
         with lsst.utils.tests.getTempFilePath(ext=".py") as configFile:
             with open(configFile, mode='wt') as config:
-                config.write('config.diaPipe.apdb.db_url = "dummy"\n')
-                config.write('config.diaPipe.apdb.dia_object_index = "pix_id_iov"\n')
+                config.write('config.db_url = "dummy"\n')
+                config.write('config.dia_object_index = "pix_id_iov"\n')
 
             args = f"-C {configFile}"
             parsed = self._parseString(args)
 
-        self.assertEqual(parsed.config.diaPipe.apdb.db_url, 'dummy')
-        self.assertEqual(parsed.config.diaPipe.apdb.dia_object_index, 'pix_id_iov')
+        self.assertEqual(parsed.config.db_url, 'dummy')
+        self.assertEqual(parsed.config.dia_object_index, 'pix_id_iov')
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_makeapdb.py
+++ b/tests/test_makeapdb.py
@@ -62,6 +62,20 @@ class MakeApdbParserTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(parsed.config.diaPipe.apdb.db_url, 'dummy')
         self.assertEqual(parsed.config.diaPipe.apdb.dia_object_index, 'pix_id_iov')
 
+    def testSetValueFile(self):
+        """Verify that config files are handled correctly.
+        """
+        with lsst.utils.tests.getTempFilePath(ext=".py") as configFile:
+            with open(configFile, mode='wt') as config:
+                config.write('config.diaPipe.apdb.db_url = "dummy"\n')
+                config.write('config.diaPipe.apdb.dia_object_index = "pix_id_iov"\n')
+
+            args = f"-C {configFile}"
+            parsed = self._parseString(args)
+
+        self.assertEqual(parsed.config.diaPipe.apdb.db_url, 'dummy')
+        self.assertEqual(parsed.config.diaPipe.apdb.dia_object_index, 'pix_id_iov')
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_makeapdb.py
+++ b/tests/test_makeapdb.py
@@ -79,6 +79,13 @@ class MakeApdbParserTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(parsed.config.db_url, 'dummy')
         self.assertEqual(parsed.config.dia_object_index, 'pix_id_iov')
 
+    def testDiaPipeDefaults(self):
+        """Verify that DiaPipelineTask's custom APDB settings are included.
+        """
+        args = '-c db_url="dummy"'
+        parsed = self._parseString(args)
+        self.assertIn("ap_association", parsed.config.extra_schema_file)
+
     @contextlib.contextmanager
     def _temporaryBuffer(self):
         tempStdErr = io.StringIO()


### PR DESCRIPTION
This PR removes the `make_apdb.py` script's dependence on `pipe_base` and on `ApPipeConfig`, making it forward-compatible with Gen 3. As a side effect, the script now loads configs at a lower level, requiring changes to calling scripts.