### PR TITLE
DM-26326: Remove obs dependency from ap_verify_testdata and ap_pipe_testdata

### DIFF
--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -53,6 +53,10 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
             cls.datadir = lsst.utils.getPackageDir("ap_pipe_testdata")
         except pexExcept.NotFoundError:
             raise unittest.SkipTest("ap_pipe_testdata not set up")
+        try:
+            lsst.utils.getPackageDir("obs_decam")
+        except LookupError:
+            raise unittest.SkipTest("obs_decam not set up; needed for ap_pipe_testdata")
 
     def _setupObjPatch(self, *args, **kwargs):
         """Create a patch in setUp that will be reverted once the test ends.

--- a/ups/ap_pipe.table
+++ b/ups/ap_pipe.table
@@ -13,6 +13,7 @@ setupRequired(pipe_tasks)
 setupRequired(ap_association)
 
 setupOptional(ap_pipe_testdata)
+setupOptional(obs_decam)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This PR compensates for the removal of the `obs_decam` dependency from lsst/ap_pipe_testdata#3 by adding a new dependency, and ensuring unit tests check separately for the testdata and the obs package being available.