### PR TITLE
DM-29221: Add ApPipe.yaml pipelines to appropriate repos

### DIFF
--- a/bps/ApPipeTemplate_bps.yaml
+++ b/bps/ApPipeTemplate_bps.yaml
@@ -1,0 +1,50 @@
+# UPDATE THIS to the path to the pipeline to run
+pipelineYaml: '${AP_PIPE_DIR}/pipelines/ApPipe.yaml'
+
+# Format for job names and job output filenames
+templateDataId: '{tract}_{patch}_{band}_{visit}_{exposure}_{detector}'
+
+# Just names, but UPDATE THIS AND KEEP THEM SHORT
+project: ApPipe
+campaign: smallrun_example
+
+submitPath: ${PWD}/bps/{outCollection}
+computeSite: ncsapool
+# Memory allocated for each quantum, in MBs
+requestMemory: 2048
+# CPUs to use per quantum
+requestCpus: 1
+
+# Example arguments, like the ones you would send to pipetask run from the command line
+payload:
+  runInit: true
+  # UPDATE THIS to also set the output collection name
+  payloadName: DM-XXXXX_ApPipe_example
+  # UPDATE THIS to point to the correct repository
+  butlerConfig: /repo/main/butler.yaml
+  # UPDATE THIS and be sure it includes collections with raws, calibs, refcats, skymaps, and templates
+  inCollection: HSC/defaults,'u/${USER}/templates'
+  # Note: keep timestamp in outCollection so you don't get a zillion sub-runs
+  output : 'u/${USER}/{payloadName}'
+  outCollection: '{output}/{timestamp}'
+  # UPDATE THIS to specify what data to process
+  dataQuery: 'exposure IN (11690, 11692) AND detector in (49, 50)'
+
+# Various things for bps to customize about each pipeline task
+pipetask:
+  # Initialization (optional, but a good idea; treated like its own pipeline task)
+  pipetaskInit:
+    runQuantumCommand: '${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions'
+  # Option to list other pipeline tasks being run here with default overrides
+  imageDifference:
+    requestMemory: 4096
+
+# Condor backend stuff
+wmsServiceClass: lsst.ctrl.bps.wms.htcondor.htcondor_service.HTCondorService
+clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.single_quantum_clustering
+
+# Create quantum graph for use by all tasks
+createQuantumGraph: '${CTRL_MPEXEC_DIR}/bin/pipetask qgraph -d "{dataQuery}" -b {butlerConfig} -i {inCollection} -p {pipelineYaml} -q {qgraphFile} --qgraph-dot {qgraphFile}.dot'
+
+# Main pipetask run call
+runQuantumCommand: '${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --extend-run --skip-init-writes --qgraph {qgraphFile} --clobber-partial-outputs --no-versions'

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -1,10 +1,18 @@
-# Gen 3 pipeline for Alert Production
+description: End to end Alert Production pipeline
+# Look in subdirectories of $AP_PIPE_DIR/pipelines to find customized pipelines
+# for each camera. Those pipelines import this general AP pipeline.
+#
+# NOTES
+# Remember to run make_apdb.py and use the same configs for diaPipe
+# READ_UNCOMMITTED is required for sqlite APDBs, i.e.,
+# -c diaPipe:apdb.isolation_level: 'READ_UNCOMMITTED'
+# A db_url is always required, e.g.,
+# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
+# Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
+# -c diaPipe:apdb.connection_timeout: 240
 
-description: End to end AP pipeline
 imports:
-  - location: $PIPE_TASKS_DIR/pipelines/DRP.yaml
-    include:
-      - processCcd
+  - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 tasks:
     imageDifference:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
@@ -14,6 +22,8 @@ tasks:
             detection.thresholdValue: 5.0  # needed with doDecorrelation
             # Don't have source catalogs for templates
             doSelectSources: False
+            # Scale diffim variance instead of template variance
+            doScaleDiffimVariance: True
     diaPipe:
         class: lsst.ap.association.DiaPipelineTask
 contracts:

--- a/pipelines/DarkEnergyCamera/ApPipe.yaml
+++ b/pipelines/DarkEnergyCamera/ApPipe.yaml
@@ -1,0 +1,20 @@
+description: End to end AP pipeline specialized for DECam
+# (1) Run $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+# (2) Execute `make_apdb.py`, e.g.,
+#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
+#                  -c db_url="sqlite:////project/user/association.db"
+# (3) Run this pipeline, setting appropriate diaPipe configs
+#     (diaPipe configs should match the make_apdb.py configs)
+
+instrument: lsst.obs.decam.DarkEnergyCamera
+imports:
+  - location: $AP_PIPE_DIR/pipelines/ApPipe.yaml
+    exclude:
+      - isr
+  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrWithCrosstalk.yaml
+tasks:
+    calibrate:
+        class: lsst.pipe.tasks.calibrate.CalibrateTask
+        config:
+          photoCal.match.referenceSelection.magLimit.fluxField: 'i_flux'
+          photoCal.match.referenceSelection.magLimit.maximum: 22.0

--- a/pipelines/DarkEnergyCamera/ApPipe_hits2015-3.yaml
+++ b/pipelines/DarkEnergyCamera/ApPipe_hits2015-3.yaml
@@ -1,0 +1,25 @@
+description: End to end AP pipeline for the repo in /project/mrawls/hits2015-3
+
+instrument: lsst.obs.decam.DarkEnergyCamera
+imports:
+  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipe.yaml
+tasks:
+    characterizeImage:
+        class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+        config:
+          refObjLoader.ref_dataset_name: 'panstarrs'
+    calibrate:
+        class: lsst.pipe.tasks.calibrate.CalibrateTask
+        config:
+          astromRefObjLoader.ref_dataset_name: 'gaia'
+          photoRefObjLoader.ref_dataset_name: 'panstarrs'
+          photoCal.photoCatName: 'panstarrs'
+          connections.astromRefCat: 'gaia'
+          connections.photoRefCat: 'panstarrs'
+          python: |
+            config.astromRefObjLoader.filterMap = {}
+            config.astromRefObjLoader.filterMap['g'] = 'phot_g_mean'
+            config.astromRefObjLoader.filterMap['r'] = 'phot_g_mean'
+            config.astromRefObjLoader.filterMap['i'] = 'phot_g_mean'
+            config.astromRefObjLoader.filterMap['z'] = 'phot_g_mean'
+            config.astromRefObjLoader.filterMap['y'] = 'phot_g_mean'

--- a/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
@@ -1,0 +1,22 @@
+description: Prepare crosstalkSources for ISR/interchip crosstalk by running overscan correction on raw frames.
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  overscan:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'overscanRaw'
+      doBias: False
+      doOverscan: True
+      doAssembleCcd: False
+      doVariance: False
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: False
+      doInterpolate: False
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False

--- a/pipelines/DarkEnergyCamera/RunIsrWithCrosstalk.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrWithCrosstalk.yaml
@@ -1,0 +1,12 @@
+description: Run ISR using pregenerated crosstalkSources for interchip crosstalk.
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.crosstalkSources: 'overscanRaw'
+      connections.bias: 'bias'  # DECam default is still 'cpBias'
+      connections.flat: 'flat'  # DECam default is still 'cpFlat'
+      doOverscan: True
+      doCrosstalk: True

--- a/pipelines/DarkEnergyCamera/RunIsrWithoutInterChipCrosstalk.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrWithoutInterChipCrosstalk.yaml
@@ -1,0 +1,9 @@
+description: Run IsrTask for DECam with only intra-chip crosstalk. Inter-chip crosstalk needs pre-prepared crosstalkSources.
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      doLinearize: False
+      doCrosstalk: True

--- a/pipelines/HyperSuprimeCam/ApPipe.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipe.yaml
@@ -1,0 +1,10 @@
+description: End to end AP pipeline specialized for HSC
+# (1) Execute `make_apdb.py`, e.g.,
+#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
+#                  -c db_url="sqlite:////project/user/association.db"
+# (2) Run this pipeline, setting appropriate diaPipe configs
+#     (diaPipe configs should match the make_apdb.py configs)
+
+instrument: lsst.obs.subaru.HyperSuprimeCam
+imports:
+  - location: $AP_PIPE_DIR/pipelines/ApPipe.yaml

--- a/pipelines/ProcessCcd.yaml
+++ b/pipelines/ProcessCcd.yaml
@@ -1,0 +1,5 @@
+description: ProcessCcd - A set of tasks to run when processing raw images.
+tasks:
+  isr: lsst.ip.isr.IsrTask
+  characterizeImage: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+  calibrate: lsst.pipe.tasks.calibrate.CalibrateTask


### PR DESCRIPTION
This PR adds a top-level `ApPipe.yaml` to `ap_pipe`. It imports from a new standalone `ProcessCcd.yaml` in the same location. In addition, there are two new subdirectories for DECam and HSC. These contain camera-specific pipelines and configurations which import from the main `ApPipe.yaml`.