### PR TITLE
DM-29344: Investigate the CI differences between Gen 2 and 3 in COSMOS field

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -22,8 +22,6 @@ tasks:
             detection.thresholdValue: 5.0  # needed with doDecorrelation
             # Don't have source catalogs for templates
             doSelectSources: False
-            # Scale diffim variance instead of template variance
-            doScaleDiffimVariance: True
     transformDiaSrcCat:
         class: lsst.ap.association.TransformDiaSourceCatalogTask
     diaPipe:


### PR DESCRIPTION
This PR does not explicitly set `doScaleDiffimVariance` in the AP pipeline. We will turn it on at the task level instead.