### PR TITLE
DM-30563: ap_verify failing to find dataset type fakes_deepDiff_warpedExp

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -23,9 +23,15 @@ tasks:
       getTemplate.coaddName: goodSeeing  # Can be removed once ImageDifference no longer supports Gen 2
       connections.coaddName: goodSeeing
       # TODO: redundant connection definitions workaround for DM-30210
+      connections.exposure: calexp
       connections.coaddExposures: goodSeeingCoadd
+      connections.dcrCoadds: dcrCoadd
+      connections.outputSchema: goodSeeingDiff_diaSrc_schema
       connections.subtractedExposure: goodSeeingDiff_differenceExp
+      connections.scoreExposure: goodSeeingDiff_scoreExp
       connections.warpedExposure: goodSeeingDiff_warpedExp
+      connections.matchedExposure: goodSeeingDiff_matchedExp
+      connections.diaSources: goodSeeingDiff_diaSrc
       # TODO: end DM-30210 workaround
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
@@ -43,6 +49,8 @@ tasks:
       connections.coaddName: goodSeeing
       # TODO: redundant connection definitions workaround for DM-30210
       connections.diaSourceTable: goodSeeingDiff_diaSrcTable
+      connections.diffIm: goodSeeingDiff_differenceExp
+      connections.warpedExposure: goodSeeingDiff_warpedExp
       connections.associatedDiaSources: goodSeeingDiff_assocDiaSrcTable
       # TODO: end DM-30210 workaround
 contracts:

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -17,31 +17,39 @@ tasks:
   imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
     config:
-      doWriteWarpedExp: True
-      coaddName: goodSeeing
-      getTemplate.coaddName: goodSeeing
+      doWriteWarpedExp: True             # Required for diaPipe
+      # 'goodSeeing' expected type for LSST processing; task default 'deep' for Gen 2 pipelines
+      coaddName: goodSeeing              # Can be removed once ImageDifference no longer supports Gen 2
+      getTemplate.coaddName: goodSeeing  # Can be removed once ImageDifference no longer supports Gen 2
       connections.coaddName: goodSeeing
+      # TODO: redundant connection definitions workaround for DM-30210
       connections.coaddExposures: goodSeeingCoadd
       connections.subtractedExposure: goodSeeingDiff_differenceExp
       connections.warpedExposure: goodSeeingDiff_warpedExp
+      # TODO: end DM-30210 workaround
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: goodSeeing
+      # TODO: redundant connection definitions workaround for DM-30210
       connections.diaSourceSchema: goodSeeingDiff_diaSrc_schema
       connections.diaSourceCat: goodSeeingDiff_diaSrc
       connections.diffIm: goodSeeingDiff_differenceExp
       connections.diaSourceTable: goodSeeingDiff_diaSrcTable
+      # TODO: end DM-30210 workaround
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       connections.coaddName: goodSeeing
+      # TODO: redundant connection definitions workaround for DM-30210
       connections.diaSourceTable: goodSeeingDiff_diaSrcTable
       connections.associatedDiaSources: goodSeeingDiff_assocDiaSrcTable
+      # TODO: end DM-30210 workaround
 contracts:
-  # DiaPipelineTask needs diaSource fluxes, catalogs, and difference exposures
+  # DiaPipelineTask needs diaSource fluxes, catalogs, warped exposures, and difference exposures
   - imageDifference.doMeasurement is True
   - imageDifference.doWriteSources is True
+  - imageDifference.doWriteWarpedExp is True
   - imageDifference.doWriteSubtractedExp is True
   # Inputs and outputs must match
   - imageDifference.connections.coaddName == transformDiaSrcCat.connections.coaddName

--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -72,6 +72,8 @@ class ApPipeConfig(pexConfig.Config):
             raise ValueError("Differencing needs calexps [ccdProcessor.calibrate.doWrite, doWriteExposure]")
         if not self.differencer.doMeasurement:
             raise ValueError("Source association needs diaSource fluxes [differencer.doMeasurement].")
+        if not self.differencer.doWriteWarpedExp:
+            raise ValueError("Alert generation needs warped exposures [differencer.doWriteWarpedExp].")
         if not self.differencer.doWriteSources:
             raise ValueError("Source association needs diaSource catalogs [differencer.doWriteSources].")
         if not self.differencer.doWriteSubtractedExp:


### PR DESCRIPTION
This PR documents the configs in `ApPipe.yaml` and extends them to cover all coadd-related connections in the main pipeline chain. This prevents downstream pipeline edits that only touch templates from creating inconsistent configs.