### PR TITLE
DM-30985: Change test to use case-insensitive search for "ap_association"

### DIFF
--- a/tests/test_makeapdb.py
+++ b/tests/test_makeapdb.py
@@ -84,7 +84,8 @@ class MakeApdbParserTestSuite(lsst.utils.tests.TestCase):
         """
         args = '-c db_url="dummy"'
         parsed = self._parseString(args)
-        self.assertIn("ap_association", parsed.config.extra_schema_file)
+        # Allow ap_association or AP_ASSOCIATION.
+        self.assertRegex(parsed.config.extra_schema_file, "(?i)ap_association")
 
     @contextlib.contextmanager
     def _temporaryBuffer(self):


### PR DESCRIPTION
The ap_association path could either be a reference to an
AP_ASSOCIATION_DIR environment variable or a fully expanded path
to the ap_association package.

Needed to support lsst/ap_association#119