### PR TITLE
DM-31220: Use new DiaPipelineTask API in ApPipeTask

### DIFF
--- a/python/lsst/ap/pipe/ap_pipe.py
+++ b/python/lsst/ap/pipe/ap_pipe.py
@@ -274,7 +274,9 @@ class ApPipeTask(pipeBase.CmdLineTask):
             diffIm=sensorRef.get(diffType + "Diff_differenceExp"),
             exposure=sensorRef.get("calexp"),
             warpedExposure=sensorRef.get(diffType + "Diff_warpedExp"),
-            ccdExposureIdBits=sensorRef.get("ccdExposureId_bits"))
+            ccdExposureIdBits=sensorRef.get("ccdExposureId_bits"),
+            band=diffIm.getFilterLabel().bandLabel,
+        )
 
         # apdb_marker triggers metrics processing; let them try to read
         # something even if association failed

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -109,10 +109,10 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
                 particular value, but have mocked methods that can be queried
                 for calls by ApPipeTask
         """
-        with patch.object(task, "ccdProcessor") as mockCcdProcessor, \
-                patch.object(task, "differencer") as mockDifferencer, \
-                patch.object(task, "transformDiaSrcCat") as mockTransform, \
-                patch.object(task, "diaPipe") as mockDiaPipe:
+        with patch.object(task, "ccdProcessor", autospec=True) as mockCcdProcessor, \
+                patch.object(task, "differencer", autospec=True) as mockDifferencer, \
+                patch.object(task, "transformDiaSrcCat", autospec=True) as mockTransform, \
+                patch.object(task, "diaPipe", autospec=True) as mockDiaPipe:
             yield pipeBase.Struct(ccdProcessor=mockCcdProcessor,
                                   differencer=mockDifferencer,
                                   transformDiaSrcCat=mockTransform,


### PR DESCRIPTION
This PR adds a missing argument to the `DiaPipelineTask` call, and updates the unit tests to catch such problems in the future.