### PR TITLE
DM-31458: Update ap_pipe for changes in APDB API

### DIFF
--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -48,8 +48,8 @@ Databases can be configured using direct config overrides (see :ref:`ap-pipe-pip
 
 .. prompt:: bash
 
-   make_apdb.py -c isolation_level=READ_UNCOMMITTED db_url="sqlite:///databases/apdb.db"
-   ap_pipe.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id [optional IDs to process]
+   make_apdb.py -c db_url="sqlite:///databases/apdb.db"
+   ap_pipe.py -c diaPipe.apdb.db_url="sqlite:///databases/apdb.db" differencer.coaddName=dcr repo --calib repo/calibs --rerun myrun --id [optional IDs to process]
 
 The user is responsible for making sure the two APDB configurations are consistent.
 
@@ -57,8 +57,8 @@ In Gen 3, this becomes (see :ref:`ap-pipe-pipeline-tutorial` for an explanation 
 
 .. prompt:: bash
 
-   make_apdb.py -c isolation_level=READ_UNCOMMITTED db_url="sqlite:///databases/apdb.db"
-   pipetask run -p ApPipe.yaml -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED diaPipe:apdb.db_url="sqlite:///databases/apdb.db" differencer:coaddName=dcr -b repo -o myrun
+   make_apdb.py -c db_url="sqlite:///databases/apdb.db"
+   pipetask run -p ApPipe.yaml -c diaPipe:apdb.db_url="sqlite:///databases/apdb.db" differencer:coaddName=dcr -b repo -o myrun
 
 .. warning::
 
@@ -72,7 +72,6 @@ Databases can also be set up using :ref:`config files <command-line-task-config-
    :caption: myApdbConfig.py
 
    config.db_url = "sqlite:///databases/apdb.db"
-   config.isolation_level = "READ_UNCOMMITTED"
 
 .. prompt:: bash
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial-gen2.rst
@@ -67,8 +67,8 @@ To process your ingested data, run
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c isolation_level=READ_UNCOMMITTED -c db_url="sqlite:///apdb/association.db"
-   ap_pipe.py repo --calib repo/calibs --rerun processed -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456^123457 ccdnum=42 filter=g --template templates
+   make_apdb.py -c db_url="sqlite:///apdb/association.db"
+   ap_pipe.py repo --calib repo/calibs --rerun processed -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456^123457 ccdnum=42 filter=g --template templates
 
 In this case, a ``processed`` directory will be created within ``repo/rerun`` and the results will be written there.
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
@@ -90,7 +90,7 @@ If you prefer to have a standalone output repository, you may instead run
 
 .. prompt:: bash
 
-   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456^123457 ccdnum=42 filter=g --template path/to/templates
+   ap_pipe.py repo --calib repo/calibs --output path/to/put/processed/data/in -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456^123457 ccdnum=42 filter=g --template path/to/templates
 
 In this case, the output directory will be created if it does not already exist.
 If you omit the ``--template`` flag, ``ap_pipe`` will assume the templates are
@@ -171,7 +171,7 @@ A full command looks like
 
 .. prompt:: bash
 
-   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c diaPipe.apdb.isolation_level=READ_UNCOMMITTED -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
+   ap_pipe.py repo --calib repo/calibs --rerun processed -C $AP_PIPE_DIR/config/calexpTemplates.py -c diaPipe.apdb.db_url="sqlite:///apdb/association.db" --id visit=123456 ccdnum=42 filter=g --template /path/to/calexp/templates --templateId visit=234567
 
 
 .. _section-ap-pipe-supplemental-info-gen2:
@@ -193,7 +193,7 @@ To get a list of all the g-band dataIds available in ``repo`` in lieu of actuall
 running ap_pipe, try
 
 .. prompt:: bash
-   
+
    ap_pipe.py repo --calib repo/calibs --rerun processed --id filter=g --show data
 
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -38,8 +38,8 @@ To process your ingested data, run
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c isolation_level=READ_UNCOMMITTED -c db_url="sqlite:///apdb/association.db"
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" -o processed -d "visit in (123456, 123457) and detector=42"
+   make_apdb.py -c db_url="sqlite:///apdb/association.db"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" -o processed -d "visit in (123456, 123457) and detector=42"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
@@ -51,7 +51,7 @@ If you prefer to have a standalone output collection, you may instead run
 
 .. prompt:: bash
 
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.isolation_level=READ_UNCOMMITTED -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" --output-run processed -d "visit in (123456, 123457) and detector=42"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" --output-run processed -d "visit in (123456, 123457) and detector=42"
 
 .. note::
 

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -4,8 +4,6 @@ description: End to end Alert Production pipeline
 #
 # NOTES
 # Remember to run make_apdb.py and use the same configs for diaPipe
-# READ_UNCOMMITTED is required for sqlite APDBs, i.e.,
-# -c diaPipe:apdb.isolation_level: 'READ_UNCOMMITTED'
 # A db_url is always required, e.g.,
 # -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,

--- a/pipelines/DarkEnergyCamera/ApPipe.yaml
+++ b/pipelines/DarkEnergyCamera/ApPipe.yaml
@@ -1,8 +1,7 @@
 description: End to end AP pipeline specialized for DECam
 # (1) Run $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
 # (2) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
 # (3) Run this pipeline, setting appropriate diaPipe configs
 #     (diaPipe configs should match the make_apdb.py configs)
 

--- a/pipelines/HyperSuprimeCam/ApPipe.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipe.yaml
@@ -1,7 +1,6 @@
 description: End to end AP pipeline specialized for HSC
 # (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
 # (2) Run this pipeline, setting appropriate diaPipe configs
 #     (diaPipe configs should match the make_apdb.py configs)
 

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -25,7 +25,7 @@ import argparse
 
 from lsst.dax.apdb import Apdb
 from lsst.pipe.base.configOverrides import ConfigOverrides
-from lsst.ap.association import DiaPipelineConfig, make_dia_object_schema, make_dia_source_schema
+from lsst.ap.association import DiaPipelineConfig
 
 
 class ConfigOnlyParser(argparse.ArgumentParser):
@@ -116,9 +116,7 @@ def makeApdb(args=None):
     parser = ConfigOnlyParser()
     parsedCmd = parser.parse_args(args=args)
 
-    apdb = Apdb(config=parsedCmd.config,
-                afw_schemas=dict(DiaObject=make_dia_object_schema(),
-                                 DiaSource=make_dia_source_schema()))
+    apdb = Apdb(config=parsedCmd.config)
     apdb.makeSchema()
     return apdb
 

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -23,7 +23,7 @@ __all__ = ["makeApdb"]
 
 import argparse
 
-from lsst.dax.apdb import Apdb
+import lsst.dax.apdb as daxApdb
 from lsst.pipe.base.configOverrides import ConfigOverrides
 from lsst.ap.association import DiaPipelineConfig
 
@@ -116,7 +116,7 @@ def makeApdb(args=None):
     parser = ConfigOnlyParser()
     parsedCmd = parser.parse_args(args=args)
 
-    apdb = Apdb(config=parsedCmd.config)
+    apdb = daxApdb.make_apdb(config=parsedCmd.config)
     apdb.makeSchema()
     return apdb
 

--- a/tests/test_appipe.py
+++ b/tests/test_appipe.py
@@ -43,7 +43,6 @@ class PipelineTestSuite(lsst.utils.tests.TestCase):
         config = ApPipeTask.ConfigClass()
         config.load(os.path.join(cls.datadir, "config", "apPipe.py"))
         config.diaPipe.apdb.db_url = "sqlite://"
-        config.diaPipe.apdb.isolation_level = "READ_UNCOMMITTED"
         return config
 
     @classmethod


### PR DESCRIPTION
Lots of small changes:

- API changed, check dax_apdb for details
- afw support dropped, we do everything with Pandas and yaml config
- no need to override default `isolation_level` in config

ap_verify works OK after all changes.
