### PR TITLE
DM-31063: Copy configs from obs_* packages to ap_pipe

### DIFF
--- a/config/DECam/apertures.py
+++ b/config/DECam/apertures.py
@@ -1,0 +1,11 @@
+# Set up aperture photometry
+# 'config' should be a SourceMeasurementConfig
+
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+# Use a large aperture to be independent of seeing in calibration
+# This config matches obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.plugins["base_CircularApertureFlux"].maxSincRadius = 12.0

--- a/config/DECam/calibrate.py
+++ b/config/DECam/calibrate.py
@@ -1,0 +1,92 @@
+"""
+DECam-specific overrides for CalibrateTask
+"""
+
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+from lsst.meas.algorithms import ColorLimit
+from lsst.meas.astrom import MatchOptimisticBConfig
+
+obsConfigDir = os.path.join(os.path.dirname(__file__))
+
+# Astrometry/Photometry
+# This sets the reference catalog name for Gen2.
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,
+                     ):
+    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+    # Note the u-band results may not be useful without a color term
+    refObjLoader.filterMap['u'] = 'g'
+    refObjLoader.filterMap['Y'] = 'y'
+    refObjLoader.filterMap['N419'] = 'g'
+    refObjLoader.filterMap['N540'] = 'g'
+    refObjLoader.filterMap['N708'] = 'i'
+    refObjLoader.filterMap['N964'] = 'z'
+
+# This sets up the reference catalog for Gen3.
+config.connections.astromRefCat = "ps1_pv3_3pi_20170110"
+config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
+
+# Photometric calibration: use color terms
+config.photoCal.applyColorTerms = True
+config.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
+colors = config.photoCal.match.referenceSelection.colorLimits
+# The following two color limits are adopted from obs_subaru for the HSC SSP survey
+colors["g-r"] = ColorLimit(primary="g_flux", secondary="r_flux", minimum=0.0)
+colors["r-i"] = ColorLimit(primary="r_flux", secondary="i_flux", maximum=0.5)
+config.photoCal.match.referenceSelection.doMagLimit = True
+config.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"
+config.photoCal.match.referenceSelection.magLimit.maximum = 22.0
+config.photoCal.colorterms.load(os.path.join(obsConfigDir, 'colorterms.py'))
+
+# Number of bright stars to use. Sets the max number of patterns that can be tested.
+# This config matches obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.astrometry.matcher.numBrightStars = 150
+
+# The Task default was reduced from 4 to 2 on RFC-577. We believe that 4 is
+# more appropriate for use with DECam data until a Jointcal-derived distortion
+# model is available (DM-24431); at that point, this override should likely be
+# removed.
+# See Slack: https://lsstc.slack.com/archives/C2B6X08LS/p1586468459084600
+config.astrometry.wcsFitter.order = 4
+
+for matchConfig in (config.astrometry,
+                    ):
+    matchConfig.sourceFluxType = 'Psf'
+    matchConfig.sourceSelector.active.sourceFluxType = 'Psf'
+    matchConfig.matcher.maxOffsetPix = 250
+    if isinstance(matchConfig.matcher, MatchOptimisticBConfig):
+        matchConfig.matcher.allowedNonperpDeg = 0.2
+        matchConfig.matcher.maxMatchDistArcSec = 2.0
+        matchConfig.sourceSelector.active.excludePixelFlags = False
+
+# Set to match defaults currently used in HSC production runs (e.g. S15B+)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+# Demand astrometry and photoCal succeed
+config.requireAstrometry = True
+config.requirePhotoCal = True
+
+config.doWriteMatchesDenormalized = True
+
+# Detection
+# This config matches obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.detection.isotropicGrow = True
+
+config.measurement.load(os.path.join(obsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(obsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(obsConfigDir, "hsm.py"))
+
+# Deblender
+# These configs match obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.deblend.maxFootprintSize = 0
+config.deblend.maskLimits["NO_DATA"] = 0.25  # Ignore sources that are in the vignetted region
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.263

--- a/config/DECam/calibrate.py
+++ b/config/DECam/calibrate.py
@@ -12,6 +12,9 @@ import os.path
 from lsst.meas.algorithms import ColorLimit
 from lsst.meas.astrom import MatchOptimisticBConfig
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 # Astrometry/Photometry

--- a/config/DECam/characterizeImage.py
+++ b/config/DECam/characterizeImage.py
@@ -11,6 +11,9 @@ import os.path
 
 from lsst.meas.astrom import MatchOptimisticBConfig
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 obsConfigDir = os.path.dirname(__file__)
 
 # Cosmic rays

--- a/config/DECam/characterizeImage.py
+++ b/config/DECam/characterizeImage.py
@@ -1,0 +1,98 @@
+"""
+DECam-specific overrides for CharacterizeImageTask
+"""
+
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+from lsst.meas.astrom import MatchOptimisticBConfig
+
+obsConfigDir = os.path.dirname(__file__)
+
+# Cosmic rays
+# These configs match obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.repair.cosmicray.nCrPixelMax = 100000
+config.repair.cosmicray.cond3_fac2 = 0.4
+
+# PSF determination
+# These configs match obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.measurePsf.reserve.fraction = 0.2
+config.measurePsf.starSelector["objectSize"].sourceFluxField = "base_PsfFlux_instFlux"
+config.measurePsf.starSelector["objectSize"].widthMin = 0.9
+config.measurePsf.starSelector["objectSize"].fluxMin = 4000
+
+# Astrometry/Photometry
+# This sets the reference catalog name for Gen2.
+# Note that in Gen3, we've stopped pretending (which is what Gen2 does,
+# for backwards compatibility) that charImage uses a reference catalog.
+config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+# Note the u-band results may not be useful without a color term
+config.refObjLoader.filterMap['u'] = 'g'
+config.refObjLoader.filterMap['Y'] = 'y'
+config.refObjLoader.filterMap['N419'] = 'g'
+config.refObjLoader.filterMap['N540'] = 'g'
+config.refObjLoader.filterMap['N708'] = 'i'
+config.refObjLoader.filterMap['N964'] = 'z'
+
+# Set to match defaults currently used in HSC production runs (e.g. S15B)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+# Detection
+# This config matches obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.detection.isotropicGrow = True
+
+# Activate calibration of measurements: required for aperture corrections
+config.load(os.path.join(obsConfigDir, "cmodel.py"))
+config.measurement.load(os.path.join(obsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(obsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(obsConfigDir, "convolvedFluxes.py"))
+config.measurement.load(os.path.join(obsConfigDir, "gaap.py"))
+config.measurement.load(os.path.join(obsConfigDir, "hsm.py"))
+if "ext_shapeHSM_HsmShapeRegauss" in config.measurement.plugins:
+    # no deblending has been done
+    config.measurement.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = ""
+
+# Deblender
+config.deblend.maskLimits["NO_DATA"] = 0.25  # Ignore sources that are in the vignetted region
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.263
+
+# Convolved fluxes can fail for small target seeing if the observation seeing is larger
+if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_convolved_ConvolvedFlux"].getAllResultNames()
+    config.measureApCorr.allowFailure += names
+
+if "ext_gaap_GaapFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
+    config.measureApCorr.allowFailure += names
+
+# For aperture correction modeling, only use objects that were used in the
+# PSF model and have psf flux signal-to-noise > 200.
+# These configs match obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.measureApCorr.sourceSelector['science'].doFlags = True
+config.measureApCorr.sourceSelector['science'].doUnresolved = False
+config.measureApCorr.sourceSelector['science'].doSignalToNoise = True
+config.measureApCorr.sourceSelector['science'].flags.good = ["calib_psf_used"]
+config.measureApCorr.sourceSelector['science'].flags.bad = []
+config.measureApCorr.sourceSelector['science'].signalToNoise.minimum = 200.0
+config.measureApCorr.sourceSelector['science'].signalToNoise.maximum = None
+config.measureApCorr.sourceSelector['science'].signalToNoise.fluxField = "base_PsfFlux_instFlux"
+config.measureApCorr.sourceSelector['science'].signalToNoise.errField = "base_PsfFlux_instFluxErr"
+config.measureApCorr.sourceSelector.name = "science"
+
+config.ref_match.sourceSelector.name = 'matcher'
+for matchConfig in (config.ref_match,
+                    ):
+    matchConfig.sourceFluxType = 'Psf'
+    matchConfig.sourceSelector.active.sourceFluxType = 'Psf'
+    matchConfig.matcher.maxOffsetPix = 250
+    if isinstance(matchConfig.matcher, MatchOptimisticBConfig):
+        matchConfig.matcher.allowedNonperpDeg = 0.2
+        matchConfig.matcher.maxMatchDistArcSec = 2.0
+        matchConfig.sourceSelector.active.excludePixelFlags = False

--- a/config/DECam/cmodel.py
+++ b/config/DECam/cmodel.py
@@ -1,0 +1,16 @@
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+# Enable CModel mags (unsetup meas_modelfit to disable)
+# 'config' is a SourceMeasurementConfig.
+try:
+    import lsst.meas.modelfit
+    config.measurement.plugins.names |= ["modelfit_DoubleShapeletPsfApprox", "modelfit_CModel"]
+    config.measurement.slots.modelFlux = 'modelfit_CModel'
+    config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.985
+except (KeyError, ImportError):
+    import logging
+    logging.getLogger("lsst.obs.decam.config").warning("Cannot import lsst.meas.modelfit:"
+                                                       " disabling CModel measurements")

--- a/config/DECam/colorterms.py
+++ b/config/DECam/colorterms.py
@@ -1,0 +1,57 @@
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+from lsst.pipe.tasks.colorterms import Colorterm, ColortermDict
+
+# Average color terms for the DECam filters are calculated using the Pickles stellar spectra atlas.
+# The following values are provided by Song Huang (Tsinghua University; dr.guangtou@gmail.com)
+# Color terms for u, Y, N419 and N964 bands are not currently available.
+
+# The values for DECam g, r & z-bands are calculated independently and are different to the values at:
+# https://www.legacysurvey.org/dr9/description/
+
+# A Jupyter notebook to reproduce these values is available at:
+# https://github.com/MerianSurvey/caterpillar/blob/main/notebook/photocal/merian_filter_color_terms.ipynb
+
+# In obs_subaru, colorterms.py is also used in:
+# - config/skyAnalysis.py
+# - config/compareCoaddAnalysis.py
+# - config/coaddAnalysis.py
+# - config/visitAnalysis.py
+# - config/fgcmBuildStarsTable.py and config/fgcmBuildStars.py
+# These files are not currently available for obs_decam.
+
+config.data = {
+    "decam*": ColortermDict(data={
+        'g DECam SDSS c0001 4720.0 1520.0': Colorterm(primary="g", secondary="g"),
+        'r DECam SDSS c0002 6415.0 1480.0': Colorterm(primary="r", secondary="r"),
+        'i DECam SDSS c0003 7835.0 1470.0': Colorterm(primary="i", secondary="i"),
+        'z DECam SDSS c0004 9260.0 1520.0': Colorterm(primary="z", secondary="z"),
+    }),
+    "sdss*": ColortermDict(data={
+        'g DECam SDSS c0001 4720.0 1520.0': Colorterm(primary="g", secondary="r", c0=-0.008015, c1=-0.089869, c2=-0.018398), # For -1.0 < g-r < 1.8
+        'r DECam SDSS c0002 6415.0 1480.0': Colorterm(primary="r", secondary="i", c0=-0.0077434, c1=-0.202615, c2=0.016042), # For -1.0 < r-i < 2.2
+        'i DECam SDSS c0003 7835.0 1470.0': Colorterm(primary="i", secondary="z", c0=0.00018887, c1=-0.2748281, c2=-0.029417), # For -1.0 < i-z < 1.2
+        'z DECam SDSS c0004 9260.0 1520.0': Colorterm(primary="z", secondary="i", c0=-0.0059858, c1=0.1131192, c2=0.0156471), # For -1.0 < z-i < 0.5
+        'N540 DECam c0014 5403.2 210.0': Colorterm(primary="g", secondary="r", c0=-0.03359776, c1=-0.57665033, c2=-0.01510509), # For -1.0 < g-r < 1.5
+        'N708 DECam c0012 7080.0 400.0': Colorterm(primary="r", secondary="i", c0=-0.01428724, c1=-0.71755905, c2=0.08959316), # For -1.0 < r-i < 2.0
+    }),
+    "hsc*": ColortermDict(data={
+        'g DECam SDSS c0001 4720.0 1520.0': Colorterm(primary="g", secondary="r", c0=0.0000509, c1=-0.0152487, c2=-0.0029937), # For -1.0 < g-r < 1.4
+        'r DECam SDSS c0002 6415.0 1480.0': Colorterm(primary="r", secondary="i", c0=-0.0078995, c1=-0.1695323, c2=0.0251978), # For -1.0 < r-i < 2.2
+        'i DECam SDSS c0003 7835.0 1470.0': Colorterm(primary="i", secondary="z", c0=0.0010196, c1=-0.1314031, c2=0.0054605), # For -1.0 < i-z < 1.0
+        'z DECam SDSS c0004 9260.0 1520.0': Colorterm(primary="z", secondary="y", c0=-0.0013244, c1=-0.2846684, c2=-0.1229817), # For -1.0 < z-y < 0.5
+        'N540 DECam c0014 5403.2 210.0': Colorterm(primary="g", secondary="r", c0=-0.03015158, c1=-0.53715834, c2=-0.00202415), # For -1.0 < g-r < 1.5
+        'N708 DECam c0012 7080.0 400.0': Colorterm(primary="r", secondary="i", c0=-0.01978413, c1=-0.64368838, c2=0.09132738), # For -1.0 < r-i < 2.0
+    }),
+    "ps1*": ColortermDict(data={
+        'g DECam SDSS c0001 4720.0 1520.0': Colorterm(primary="g", secondary="r", c0=0.006388, c1=0.045875, c2=-0.004484), # For -1.0 < g-r < 1.2
+        'r DECam SDSS c0002 6415.0 1480.0': Colorterm(primary="r", secondary="i", c0=-0.006775, c1=-0.187304, c2=0.018928), # For -1.0 < r-i < 2.2
+        'i DECam SDSS c0003 7835.0 1470.0': Colorterm(primary="i", secondary="z", c0=0.0012204, c1=-0.282956, c2=-0.011321), # For -1.0 < i-z < 1.4
+        'z DECam SDSS c0004 9260.0 1520.0': Colorterm(primary="z", secondary="y", c0=-0.0087868, c1=-0.5204795, c2=-0.057955), # For -1.0 < z-y < 1.0
+        'N540 DECam c0014 5403.2 210.0': Colorterm(primary="g", secondary="r", c0=-0.02635164, c1=-0.50968428, c2=-0.00958104), # For -1.0 < g-r < 1.5
+        'N708 DECam c0012 7080.0 400.0': Colorterm(primary="r", secondary="i", c0=-0.01508987, c1=-0.69377675, c2=0.09079348), # For -1.0 < r-i < 2.0
+    }),
+}

--- a/config/DECam/convolvedFluxes.py
+++ b/config/DECam/convolvedFluxes.py
@@ -1,0 +1,16 @@
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+# Enable measurement of convolved fluxes
+# 'config' is a SourceMeasurementConfig
+try:
+    import lsst.meas.extensions.convolved  # noqa: Load flux.convolved algorithm
+except ImportError as exc:
+    import logging
+    logging.getLogger("lsst.obs.decam.config").warning("Cannot import lsst.meas.extensions.convolved (%s):"
+                                                       " disabling convolved flux measurements", exc)
+else:
+    config.plugins.names.add("ext_convolved_ConvolvedFlux")
+    config.plugins["ext_convolved_ConvolvedFlux"].seeing.append(8.0)

--- a/config/DECam/gaap.py
+++ b/config/DECam/gaap.py
@@ -1,0 +1,17 @@
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+# Enable GAaP (Gaussian Aperture and PSF) colors
+# 'config' is typically a SourceMeasurementConfig
+try:
+    import lsst.meas.extensions.gaap  # noqa
+    config.plugins.names.add("ext_gaap_GaapFlux")
+    config.plugins["ext_gaap_GaapFlux"].sigmas = [0.5, 0.7, 1.0, 1.5, 2.5, 3.0]
+    # Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+    config.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
+except ImportError as exc:
+    import logging
+    logging.getLogger("lsst.obs.decam.config").warning("Cannot import lsst.meas.extensions.gaap (%s):"
+                                                       " disabling GAaP flux measurements", exc)

--- a/config/DECam/hsm.py
+++ b/config/DECam/hsm.py
@@ -1,0 +1,18 @@
+# Enable HSM shapes (unsetup meas_extensions_shapeHSM to disable)
+# 'config' is a SourceMeasurementConfig.
+
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+from lsst.utils import getPackageDir
+
+try:
+    config.load(os.path.join(getPackageDir("meas_extensions_shapeHSM"), "config", "enable.py"))
+    config.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = "deblend_nChild"
+    # Enable debiased moments
+    config.plugins.names |= ["ext_shapeHSM_HsmPsfMomentsDebiased"]
+except LookupError as e:
+    print("Cannot enable shapeHSM (%s): disabling HSM shape measurements" % (e,))

--- a/config/DECam/kron.py
+++ b/config/DECam/kron.py
@@ -1,0 +1,15 @@
+# Enable Kron mags
+# 'config' is a SourceMeasurementConfig
+
+# This file was copied from obs_decam as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+try:
+    import lsst.meas.extensions.photometryKron
+    config.plugins.names |= ["ext_photometryKron_KronFlux"]
+except ImportError:
+    import logging
+    logging.getLogger("lsst.obs.decam.config").warning("Cannot import lsst.meas.extensions.photometryKron:"
+                                                       " disabling Kron measurements")

--- a/config/HSC/apertures.py
+++ b/config/HSC/apertures.py
@@ -1,0 +1,15 @@
+# Set up aperture photometry
+# 'config' should be a SourceMeasurementConfig
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.plugins.names |= ["base_CircularApertureFlux"]
+# Roughly (1.0, 1.5, 2.0, 3.0, 4.0, 5.7, 8.4, 11.8, 16.8, 23.5 arcsec) in diameter: 2**(0.5*i)
+# (assuming plate scale of 0.168 arcsec pixels)
+config.plugins["base_CircularApertureFlux"].radii = [3.0, 4.5, 6.0, 9.0, 12.0, 17.0, 25.0, 35.0, 50.0, 70.0]
+
+# Use a large aperture to be independent of seeing in calibration
+config.plugins["base_CircularApertureFlux"].maxSincRadius = 12.0

--- a/config/HSC/assembleCoadd.py
+++ b/config/HSC/assembleCoadd.py
@@ -5,6 +5,9 @@
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs.
+config = type(config)()
+
 # Load configs shared between assembleCoadd and makeCoaddTempExp
 config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 

--- a/config/HSC/assembleCoadd.py
+++ b/config/HSC/assembleCoadd.py
@@ -1,0 +1,24 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
+
+config.doSigmaClip = False
+# 200 rows (since patch width is typically < 10k pixels)
+config.subregionSize = (10000, 200)
+config.doMaskBrightObjects = True
+config.removeMaskPlanes.append("CROSSTALK")
+config.doNImage = True
+config.badMaskPlanes += ["SUSPECT"]
+config.doAttachTransmissionCurve = True
+# Saturation trails are usually oriented east-west, so along rows
+config.interpImage.transpose = True
+config.coaddPsf.warpingKernelName = 'lanczos5'
+
+from lsst.pipe.tasks.selectImages import PsfWcsSelectImagesTask
+config.select.retarget(PsfWcsSelectImagesTask)

--- a/config/HSC/background.py
+++ b/config/HSC/background.py
@@ -1,0 +1,7 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.binSize = 128
+config.useApprox = True

--- a/config/HSC/calibrate.py
+++ b/config/HSC/calibrate.py
@@ -1,0 +1,81 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+from lsst.meas.algorithms import ColorLimit
+from lsst.meas.astrom import MatchOptimisticBConfig
+
+ObsConfigDir = os.path.dirname(__file__)
+
+bgFile = os.path.join(ObsConfigDir, "background.py")
+
+# Cosmic rays and background estimation
+config.detection.background.load(bgFile)
+
+# Reference catalogs
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,
+                     ):
+    refObjLoader.load(os.path.join(ObsConfigDir, "filterMap.py"))
+    # This is the Gen2 configuration option.
+    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+
+# These are the Gen3 configuration options for reference catalog name.
+config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
+config.connections.astromRefCat = "ps1_pv3_3pi_20170110"
+
+# Better astrometry matching
+config.astrometry.matcher.numBrightStars = 150
+
+# Set to match defaults currently used in HSC production runs (e.g. S15B)
+config.astrometry.wcsFitter.numRejIter = 3
+config.astrometry.wcsFitter.order = 3
+
+for matchConfig in (config.astrometry,
+                    ):
+    matchConfig.sourceFluxType = 'Psf'
+    matchConfig.sourceSelector.active.sourceFluxType = 'Psf'
+    matchConfig.matcher.maxRotationDeg = 1.145916
+    matchConfig.matcher.maxOffsetPix = 250
+    if isinstance(matchConfig.matcher, MatchOptimisticBConfig):
+        matchConfig.matcher.allowedNonperpDeg = 0.2
+        matchConfig.matcher.maxMatchDistArcSec = 2.0
+        matchConfig.sourceSelector.active.excludePixelFlags = False
+
+# Set to match defaults curretnly used in HSC production runs (e.g. S15B)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+config.photoCal.applyColorTerms = True
+config.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
+colors = config.photoCal.match.referenceSelection.colorLimits
+colors["g-r"] = ColorLimit(primary="g_flux", secondary="r_flux", minimum=0.0)
+colors["r-i"] = ColorLimit(primary="r_flux", secondary="i_flux", maximum=0.5)
+config.photoCal.match.referenceSelection.doMagLimit = True
+config.photoCal.match.referenceSelection.magLimit.fluxField = "i_flux"
+config.photoCal.match.referenceSelection.magLimit.maximum = 22.0
+config.photoCal.colorterms.load(os.path.join(ObsConfigDir, 'colorterms.py'))
+
+# Demand astrometry and photoCal succeed
+config.requireAstrometry = True
+config.requirePhotoCal = True
+
+config.doWriteMatchesDenormalized = True
+
+# Detection
+config.detection.isotropicGrow = True
+
+config.measurement.load(os.path.join(ObsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "hsm.py"))
+
+# Deblender
+config.deblend.maxFootprintSize = 0
+# Ignore sources that are in the vignetted region
+config.deblend.maskLimits["NO_DATA"] = 0.25
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.168

--- a/config/HSC/calibrate.py
+++ b/config/HSC/calibrate.py
@@ -8,6 +8,9 @@ import os.path
 from lsst.meas.algorithms import ColorLimit
 from lsst.meas.astrom import MatchOptimisticBConfig
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 ObsConfigDir = os.path.dirname(__file__)
 
 bgFile = os.path.join(ObsConfigDir, "background.py")

--- a/config/HSC/characterizeImage.py
+++ b/config/HSC/characterizeImage.py
@@ -8,6 +8,9 @@ import os.path
 from lsst.meas.algorithms import ColorLimit
 from lsst.meas.astrom import MatchOptimisticBConfig
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 ObsConfigDir = os.path.dirname(__file__)
 
 bgFile = os.path.join(ObsConfigDir, "background.py")

--- a/config/HSC/characterizeImage.py
+++ b/config/HSC/characterizeImage.py
@@ -1,0 +1,91 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+from lsst.meas.algorithms import ColorLimit
+from lsst.meas.astrom import MatchOptimisticBConfig
+
+ObsConfigDir = os.path.dirname(__file__)
+
+bgFile = os.path.join(ObsConfigDir, "background.py")
+
+# Cosmic rays and background estimation
+config.repair.cosmicray.nCrPixelMax = 1000000
+config.repair.cosmicray.cond3_fac2 = 0.4
+config.background.load(bgFile)
+config.detection.background.load(bgFile)
+
+# PSF determination
+config.measurePsf.reserve.fraction = 0.2
+config.measurePsf.starSelector["objectSize"].sourceFluxField = "base_PsfFlux_instFlux"
+config.measurePsf.starSelector["objectSize"].widthMin = 0.9
+config.measurePsf.starSelector["objectSize"].fluxMin = 4000
+
+# Astrometry
+config.refObjLoader.load(os.path.join(ObsConfigDir, "filterMap.py"))
+config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+
+for refObjLoader in (config.refObjLoader,
+                     ):
+    refObjLoader.load(os.path.join(ObsConfigDir, "filterMap.py"))
+
+# Set to match defaults curretnly used in HSC production runs (e.g. S15B)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+# Detection
+config.detection.isotropicGrow = True
+
+# Activate calibration of measurements: required for aperture corrections
+config.load(os.path.join(ObsConfigDir, "cmodel.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "convolvedFluxes.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "gaap.py"))
+config.measurement.load(os.path.join(ObsConfigDir, "hsm.py"))
+if "ext_shapeHSM_HsmShapeRegauss" in config.measurement.plugins:
+    # no deblending has been done
+    config.measurement.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = ""
+
+# Deblender
+config.deblend.maskLimits["NO_DATA"] = 0.25 # Ignore sources that are in the vignetted region
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.168
+
+# Convolved fluxes can fail for small target seeing if the observation seeing is larger
+if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_convolved_ConvolvedFlux"].getAllResultNames()
+    config.measureApCorr.allowFailure += names
+
+if "ext_gaap_GaapFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
+    config.measureApCorr.allowFailure += names
+
+# For aperture correction modeling, only use objects that were used in the
+# PSF model and have psf flux signal-to-noise > 200.
+config.measureApCorr.sourceSelector['science'].doFlags = True
+config.measureApCorr.sourceSelector['science'].doUnresolved = False
+config.measureApCorr.sourceSelector['science'].doSignalToNoise = True
+config.measureApCorr.sourceSelector['science'].flags.good = ["calib_psf_used"]
+config.measureApCorr.sourceSelector['science'].flags.bad = []
+config.measureApCorr.sourceSelector['science'].signalToNoise.minimum = 200.0
+config.measureApCorr.sourceSelector['science'].signalToNoise.maximum = None
+config.measureApCorr.sourceSelector['science'].signalToNoise.fluxField = "base_PsfFlux_instFlux"
+config.measureApCorr.sourceSelector['science'].signalToNoise.errField = "base_PsfFlux_instFluxErr"
+config.measureApCorr.sourceSelector.name = "science"
+
+config.ref_match.sourceSelector.name = 'matcher'
+for matchConfig in (config.ref_match,
+                    ):
+    matchConfig.sourceFluxType = 'Psf'
+    matchConfig.sourceSelector.active.sourceFluxType = 'Psf'
+    matchConfig.matcher.maxRotationDeg = 1.145916
+    matchConfig.matcher.maxOffsetPix = 250
+    if isinstance(matchConfig.matcher, MatchOptimisticBConfig):
+        matchConfig.matcher.allowedNonperpDeg = 0.2
+        matchConfig.matcher.maxMatchDistArcSec = 2.0
+        matchConfig.sourceSelector.active.excludePixelFlags = False

--- a/config/HSC/cmodel.py
+++ b/config/HSC/cmodel.py
@@ -1,0 +1,15 @@
+# Enable CModel mags (unsetup meas_modelfit to disable)
+# 'config' is a SourceMeasurementConfig.
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+try:
+    import lsst.meas.modelfit
+    config.measurement.plugins.names |= ["modelfit_DoubleShapeletPsfApprox", "modelfit_CModel"]
+    config.measurement.slots.modelFlux = 'modelfit_CModel'
+    config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.985
+except (KeyError, ImportError):
+    print("Cannot import lsst.meas.modelfit: disabling CModel measurements")

--- a/config/HSC/coaddBase.py
+++ b/config/HSC/coaddBase.py
@@ -1,0 +1,10 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+# Configs shared between makeCoaddTempExp and assemble
+config.matchingKernelSize = 29
+config.doApplyExternalPhotoCalib = True
+config.externalPhotoCalibName = 'fgcm'
+config.doApplyExternalSkyWcs = True

--- a/config/HSC/colorterms.py
+++ b/config/HSC/colorterms.py
@@ -1,0 +1,60 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+from lsst.pipe.tasks.colorterms import Colorterm, ColortermDict
+
+config.data = {
+    "hsc*": ColortermDict(data={
+        'HSC-G': Colorterm(primary="g", secondary="g"),
+        'HSC-R': Colorterm(primary="r", secondary="r"),
+        'HSC-I': Colorterm(primary="i", secondary="i"),
+        'HSC-Z': Colorterm(primary="z", secondary="z"),
+        'HSC-Y': Colorterm(primary="y", secondary="y"),
+    }),
+    "sdss*": ColortermDict(data={
+        'HSC-G': Colorterm(primary="g", secondary="r", c0=-0.009777, c1=-0.077235, c2=-0.013121),
+        'HSC-R': Colorterm(primary="r", secondary="i", c0=-0.000711, c1=-0.006847, c2=-0.035110),
+        'HSC-R2': Colorterm(primary="r", secondary="i", c0=-0.000632, c1=-0.011237, c2=-0.038169),
+        'HSC-I': Colorterm(primary="i", secondary="z", c0=0.000357, c1=-0.153290, c2=-0.009277),
+        'HSC-I2': Colorterm(primary="i", secondary="z", c0=0.001278, c1=-0.213569, c2=-0.012523),
+        'HSC-Z': Colorterm(primary="z", secondary="i", c0=-0.005761, c1=0.001317, c2=-0.035334),
+        'HSC-Y': Colorterm(primary="z", secondary="i", c0=0.003386, c1=0.428877, c2=0.076738),
+        'IB0945': Colorterm(primary="z", secondary="i", c0=0.008117, c1=0.234991, c2=-0.042255),
+        'NB0387': Colorterm(primary="u", secondary="g", c0=-0.709229, c1=0.310719, c2=-0.044107),
+        'NB0400': Colorterm(primary="u", secondary="g", c0=-0.396264, c1=-0.395133, c2=0.038688),
+        'NB0468': Colorterm(primary="g", secondary="r", c0=-0.059159, c1=-0.030881, c2=0.015356),
+        'NB0515': Colorterm(primary="g", secondary="r", c0=-0.032510, c1=-0.354440, c2=0.100832),
+        'NB0527': Colorterm(primary="g", secondary="r", c0=-0.029400, c1=-0.453037, c2=0.020922),
+        'NB0656': Colorterm(primary="r", secondary="i", c0=0.037014, c1=-0.538947, c2=0.052489),
+        'NB0718': Colorterm(primary="r", secondary="i", c0=-0.014742, c1=-0.787571, c2=0.237867),
+        'NB0816': Colorterm(primary="i", secondary="z", c0=0.012676, c1=-0.660317, c2=0.055566),
+        'NB0921': Colorterm(primary="z", secondary="i", c0=0.004619, c1=0.093019, c2=-0.126377),
+        'NB0926': Colorterm(primary="z", secondary="i", c0=0.009369, c1=0.130261, c2=-0.119282),
+        'NB0973': Colorterm(primary="z", secondary="i", c0=-0.005805, c1=0.220412, c2=-0.249072),
+        'NB01010': Colorterm(primary="z", secondary="i", c0=0.015296, c1=0.794152, c2=0.465309),
+    }),
+    "ps1*": ColortermDict(data={
+        'HSC-G': Colorterm(primary="g", secondary="r", c0=0.005728, c1=0.061749, c2=-0.001125),
+        'HSC-R': Colorterm(primary="r", secondary="i", c0=-0.000144, c1=0.001369, c2=-0.008380),
+        'HSC-R2': Colorterm(primary="r", secondary="i", c0=-0.000032, c1=-0.002866, c2=-0.012638),
+        'HSC-I': Colorterm(primary="i", secondary="z", c0=0.000643, c1=-0.130078, c2=-0.006855),
+        'HSC-I2': Colorterm(primary="i", secondary="z", c0=0.001625, c1=-0.200406, c2=-0.013666),
+        'HSC-Z': Colorterm(primary="z", secondary="y", c0=-0.005362, c1=-0.221551, c2=-0.308279),
+        'HSC-Y': Colorterm(primary="y", secondary="z", c0=-0.002055, c1=0.209680, c2=0.227296),
+        'IB0945': Colorterm(primary="y", secondary="z", c0=0.005275, c1=-0.194285, c2=-0.125424),
+        'NB0387': Colorterm(primary="g", secondary="r", c0=0.427879, c1=1.869068, c2=0.540580),
+        'NB0400': Colorterm(primary="g", secondary="r", c0=0.176542, c1=1.127055, c2=0.505502),
+        'NB0468': Colorterm(primary="g", secondary="r", c0=-0.042240, c1=0.121756, c2=0.027599),
+        'NB0515': Colorterm(primary="g", secondary="r", c0=-0.021913, c1=-0.253159, c2=0.151553),
+        'NB0527': Colorterm(primary="g", secondary="r", c0=-0.020641, c1=-0.366167, c2=0.038497),
+        'NB0656': Colorterm(primary="r", secondary="i", c0=0.035655, c1=-0.512046, c2=0.042796),
+        'NB0718': Colorterm(primary="i", secondary="r", c0=-0.016294, c1=-0.233139, c2=0.252505),
+        'NB0816': Colorterm(primary="i", secondary="z", c0=0.013806, c1=-0.717681, c2=0.049289),
+        'NB0921': Colorterm(primary="z", secondary="y", c0=0.002039, c1=-0.477412, c2=-0.492151),
+        'NB0926': Colorterm(primary="z", secondary="y", c0=0.005230, c1=-0.574448, c2=-0.330899),
+        'NB0973': Colorterm(primary="y", secondary="z", c0=-0.007775, c1=-0.050972, c2=-0.197278),
+        'NB01010': Colorterm(primary="y", secondary="z", c0=0.003607, c1=0.865366, c2=1.271817),
+    }),
+}

--- a/config/HSC/convolvedFluxes.py
+++ b/config/HSC/convolvedFluxes.py
@@ -1,0 +1,15 @@
+# Enable measurement of convolved fluxes
+# 'config' is a SourceMeasurementConfig
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+try:
+    import lsst.meas.extensions.convolved  # noqa: Load flux.convolved algorithm
+except ImportError as exc:
+    print("Cannot import lsst.meas.extensions.convolved (%s): disabling convolved flux measurements" % (exc,))
+else:
+    config.plugins.names.add("ext_convolved_ConvolvedFlux")
+    config.plugins["ext_convolved_ConvolvedFlux"].seeing.append(8.0)

--- a/config/HSC/filterMap.py
+++ b/config/HSC/filterMap.py
@@ -1,0 +1,51 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+for source, target in [
+        # Names used by Exposure.getFilter() in Gen2.
+        # Wide bands
+        ("r2", "r"),
+        ("i2", "i"),
+        # Narrow bands
+        ('N387', 'g'),
+        ('N468', 'g'),
+        ('N515', 'g'),
+        ('N527', 'g'),
+        ('N656', 'r'),
+        ('N718', 'i'),
+        ('N816', 'i'),
+        ('N921', 'z'),
+        ('N926', 'z'),
+        ('N973', 'y'),
+        ('N1010', 'y'),
+        # Intermediate bands
+        ('I945', 'z'),
+
+        # Names used by data IDs in both Gen2 and Gen3, and
+        # Exposure.getFilter() in Gen3 (mappings are the same).
+        # Wide bands
+        ("HSC-G", "g"),
+        ("HSC-R", "r"),
+        ("HSC-R2", "r"),
+        ("HSC-I", "i"),
+        ("HSC-I2", "i"),
+        ("HSC-Z", "z"),
+        ("HSC-Y", "y"),
+        # Narrow bands
+        ('NB0387', 'g'),
+        ('NB0468', 'g'),
+        ('NB0515', 'g'),
+        ('NB0527', 'g'),
+        ('NB0656', 'r'),
+        ('NB0718', 'i'),
+        ('NB0816', 'i'),
+        ('NB0921', 'z'),
+        ('NB0926', 'z'),
+        ('NB0973', 'y'),
+        ('NB1010', 'y'),
+        # Intermediate bands
+        ('IB0945', 'z'),
+    ]:
+    config.filterMap[source] = target

--- a/config/HSC/gaap.py
+++ b/config/HSC/gaap.py
@@ -1,0 +1,16 @@
+# Enable GAaP (Gaussian Aperture and PSF) colors
+# 'config' is typically a SourceMeasurementConfig
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+try:
+    import lsst.meas.extensions.gaap  # noqa
+    config.plugins.names.add("ext_gaap_GaapFlux")
+    config.plugins["ext_gaap_GaapFlux"].sigmas = [0.5, 0.7, 1.0, 1.5, 2.5, 3.0]
+    # Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+    config.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True
+except ImportError as exc:
+    print("Cannot import lsst.meas.extensions.gaap (%s): disabling GAaP flux measurements" % (exc,))

--- a/config/HSC/hsm.py
+++ b/config/HSC/hsm.py
@@ -1,0 +1,18 @@
+# Enable HSM shapes (unsetup meas_extensions_shapeHSM to disable)
+# 'config' is a SourceMeasurementConfig.
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+from lsst.utils import getPackageDir
+
+try:
+    config.load(os.path.join(getPackageDir("meas_extensions_shapeHSM"), "config", "enable.py"))
+    config.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = "deblend_nChild"
+    # Enable debiased moments
+    config.plugins.names |= ["ext_shapeHSM_HsmPsfMomentsDebiased"]
+except LookupError as e:
+    print("Cannot enable shapeHSM (%s): disabling HSM shape measurements" % (e,))

--- a/config/HSC/kron.py
+++ b/config/HSC/kron.py
@@ -1,0 +1,13 @@
+# Enable Kron mags
+# 'config' is a SourceMeasurementConfig
+
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+try:
+    import lsst.meas.extensions.photometryKron
+    config.plugins.names |= ["ext_photometryKron_KronFlux"]
+except ImportError:
+    print("Cannot import lsst.meas.extensions.photometryKron: disabling Kron measurements")

--- a/config/HSC/makeWarp.py
+++ b/config/HSC/makeWarp.py
@@ -5,6 +5,9 @@
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs.
+config = type(config)()
+
 # Load configs shared between assembleCoadd and makeWarp
 config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 

--- a/config/HSC/makeWarp.py
+++ b/config/HSC/makeWarp.py
@@ -1,0 +1,17 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+# Load configs shared between assembleCoadd and makeWarp
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
+
+config.makePsfMatched = True
+config.doApplySkyCorr = True
+
+config.modelPsf.defaultFwhm = 7.7
+config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
+config.warpAndPsfMatch.warp.warpingKernelName = 'lanczos5'
+config.coaddPsf.warpingKernelName = 'lanczos5'

--- a/config/HSC/processCcdWithFakes.py
+++ b/config/HSC/processCcdWithFakes.py
@@ -1,0 +1,10 @@
+# This file was copied from obs_subaru as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+ObsConfigDir = os.path.dirname(__file__)
+calFile = os.path.join(ObsConfigDir, "calibrate.py")
+config.calibrate.load(calFile)

--- a/config/HSC/processCcdWithFakes.py
+++ b/config/HSC/processCcdWithFakes.py
@@ -5,6 +5,9 @@
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 ObsConfigDir = os.path.dirname(__file__)
 calFile = os.path.join(ObsConfigDir, "calibrate.py")
 config.calibrate.load(calFile)

--- a/config/LSSTCam-imSim/apertures.py
+++ b/config/LSSTCam-imSim/apertures.py
@@ -1,0 +1,38 @@
+# Set up aperture photometry
+
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# 'config' should be a SourceMeasurementConfig
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.plugins.names |= ["base_CircularApertureFlux"]
+# Roughly (1.0, 1.4, 2.0, 2.8, 4.0, 5.7, 8.0, 11.3, 16.0, 22.6 arcsec) in diameter: 2**(0.5*i)
+# (assuming plate scale of 0.168 arcsec pixels)
+config.plugins["base_CircularApertureFlux"].radii = [3.0, 4.5, 6.0, 9.0, 12.0, 17.0, 25.0, 35.0, 50.0, 70.0]
+
+# Use a large aperture to be independent of seeing in calibration
+config.plugins["base_CircularApertureFlux"].maxSincRadius = 12.0

--- a/config/LSSTCam-imSim/assembleCoadd.py
+++ b/config/LSSTCam-imSim/assembleCoadd.py
@@ -1,0 +1,43 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
+
+config.doSigmaClip = False
+config.subregionSize = (10000, 200) # 200 rows (since patch width is typically < 10k pixels)
+config.removeMaskPlanes.append("CROSSTALK")
+config.doNImage = True
+config.badMaskPlanes += ["SUSPECT"]
+
+from lsst.pipe.tasks.selectImages import PsfWcsSelectImagesTask
+config.select.retarget(PsfWcsSelectImagesTask)
+
+# FUTURE: Set to True when we get transmission curves
+config.doAttachTransmissionCurve = False

--- a/config/LSSTCam-imSim/assembleCoadd.py
+++ b/config/LSSTCam-imSim/assembleCoadd.py
@@ -27,6 +27,9 @@
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs.
+config = type(config)()
+
 # Load configs shared between assembleCoadd and makeCoaddTempExp
 config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 

--- a/config/LSSTCam-imSim/background.py
+++ b/config/LSSTCam-imSim/background.py
@@ -1,0 +1,29 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.binSize = 128
+config.useApprox = True

--- a/config/LSSTCam-imSim/calibrate.py
+++ b/config/LSSTCam-imSim/calibrate.py
@@ -1,0 +1,120 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""
+LSST Cam-specific overrides for CalibrateTask
+"""
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+obsConfigDir = os.path.join(os.path.dirname(__file__))
+
+bgFile = os.path.join(obsConfigDir, "background.py")
+
+# Cosmic rays and background estimation
+config.detection.background.load(bgFile)
+
+# Enable temporary local background subtraction
+config.detection.doTempLocalBackground  = True
+
+# Reference catalog
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,
+                     ):
+    refObjLoader.load(os.path.join(obsConfigDir, 'filterMap.py'))
+    refObjLoader.ref_dataset_name = 'cal_ref_cat'
+
+config.connections.astromRefCat = "cal_ref_cat"
+config.connections.photoRefCat = "cal_ref_cat"
+
+# Set to match defaults currenyly used in HSC production runs (e.g. S15B)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+# No color term in simulation at the moment
+config.photoCal.applyColorTerms = False
+config.photoCal.match.referenceSelection.doMagLimit = True
+config.photoCal.match.referenceSelection.magLimit.fluxField = "lsst_i_smeared_flux"
+config.photoCal.match.referenceSelection.magLimit.maximum = 22.0
+# select only stars for photometry calibration
+config.photoCal.match.sourceSelection.unresolved.maximum = 0.5
+
+# Demand astrometry and photoCal succeed
+config.requireAstrometry = True
+config.requirePhotoCal = True
+
+# Detection
+config.detection.isotropicGrow = True
+
+# Activate calibration of measurements: required for aperture corrections
+config.measurement.load(os.path.join(obsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(obsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(obsConfigDir, "hsm.py"))
+
+# Deblender
+config.deblend.maxFootprintSize = 0
+config.deblend.maskLimits["NO_DATA"] = 0.25 # Ignore sources that are in the vignetted region
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.2
+
+# Prevent spurious detections in vignetting areas
+config.detection.thresholdType = 'pixel_stdev'
+
+# This file was inserted from obs_lsst/config/imsim/calibrate.py as part of
+# DM-31063. Feel free to modify this file to better reflect the needs of AP;
+# however, when it comes time to permanently remove the obs_* configs, we
+# should check that none of the changes made there since April 12, 2022 would
+# be useful here.
+
+# Additional configs for star+galaxy ref cats post DM-17917
+config.astrometry.referenceSelector.doUnresolved = True
+config.astrometry.referenceSelector.unresolved.name = "resolved"
+config.astrometry.referenceSelector.unresolved.minimum = None
+config.astrometry.referenceSelector.unresolved.maximum = 0.5
+
+config.astrometry.doMagnitudeOutlierRejection = True
+# Set threshold above which astrometry will be considered a failure (DM-32129)
+config.astrometry.maxMeanDistanceArcsec = 0.05
+
+# Reduce Chebyshev polynomial order for background fitting (DM-30820)
+config.detection.background.approxOrderX = 1
+config.detection.tempLocalBackground.approxOrderX = 1
+config.detection.tempWideBackground.approxOrderX = 1
+
+# Make sure galaxies are not used for zero-point calculation.
+config.photoCal.match.referenceSelection.doUnresolved = True
+config.photoCal.match.referenceSelection.unresolved.name = "resolved"
+config.photoCal.match.referenceSelection.unresolved.minimum = None
+config.photoCal.match.referenceSelection.unresolved.maximum = 0.5
+
+# S/N cuts for zero-point calculation source selection
+config.photoCal.match.sourceSelection.doSignalToNoise = True
+config.photoCal.match.sourceSelection.signalToNoise.minimum = 150
+config.photoCal.match.sourceSelection.signalToNoise.fluxField = "base_PsfFlux_instFlux"
+config.photoCal.match.sourceSelection.signalToNoise.errField = "base_PsfFlux_instFluxErr"

--- a/config/LSSTCam-imSim/calibrate.py
+++ b/config/LSSTCam-imSim/calibrate.py
@@ -31,6 +31,9 @@ LSST Cam-specific overrides for CalibrateTask
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 bgFile = os.path.join(obsConfigDir, "background.py")

--- a/config/LSSTCam-imSim/characterizeImage.py
+++ b/config/LSSTCam-imSim/characterizeImage.py
@@ -31,6 +31,9 @@ LSST Cam-specific overrides for CharacterizeImageTask
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config = type(config)()
+
 obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 bgFile = os.path.join(obsConfigDir, "background.py")

--- a/config/LSSTCam-imSim/characterizeImage.py
+++ b/config/LSSTCam-imSim/characterizeImage.py
@@ -1,0 +1,117 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""
+LSST Cam-specific overrides for CharacterizeImageTask
+"""
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+obsConfigDir = os.path.join(os.path.dirname(__file__))
+
+bgFile = os.path.join(obsConfigDir, "background.py")
+
+# Cosmic rays and background estimation
+config.repair.cosmicray.nCrPixelMax = 1000000
+config.repair.cosmicray.cond3_fac2 = 0.4
+config.background.load(bgFile)
+config.detection.background.load(bgFile)
+
+# Enable temporary local background subtraction
+config.detection.doTempLocalBackground=True
+
+# PSF determination
+config.measurePsf.reserve.fraction = 0.2
+config.measurePsf.starSelector["objectSize"].sourceFluxField = 'base_PsfFlux_instFlux'
+
+# Astrometry
+config.refObjLoader.load(os.path.join(obsConfigDir, 'filterMap.py'))
+config.refObjLoader.ref_dataset_name = 'cal_ref_cat'
+
+# Set to match defaults currenyly used in HSC production runs (e.g. S15B)
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+# Detection
+config.detection.isotropicGrow = True
+
+# Activate calibration of measurements: required for aperture corrections
+config.load(os.path.join(obsConfigDir, "cmodel.py"))
+config.measurement.load(os.path.join(obsConfigDir, "apertures.py"))
+config.measurement.load(os.path.join(obsConfigDir, "kron.py"))
+config.measurement.load(os.path.join(obsConfigDir, "convolvedFluxes.py"))
+config.measurement.load(os.path.join(obsConfigDir, "gaap.py"))
+config.measurement.load(os.path.join(obsConfigDir, "hsm.py"))
+if "ext_shapeHSM_HsmShapeRegauss" in config.measurement.plugins:
+    # no deblending has been done
+    config.measurement.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = ""
+
+# Deblender
+config.deblend.maskLimits["NO_DATA"] = 0.25 # Ignore sources that are in the vignetted region
+config.deblend.maxFootprintArea = 10000
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+
+# Convolved fluxes can fail for small target seeing if the observation seeing is larger
+if "ext_convolved_ConvolvedFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_convolved_ConvolvedFlux"].getAllResultNames()
+    config.measureApCorr.allowFailure += names
+
+if "ext_gaap_GaapFlux" in config.measurement.plugins:
+    names = config.measurement.plugins["ext_gaap_GaapFlux"].getAllGaapResultNames()
+    config.measureApCorr.allowFailure += names
+
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.2
+
+# Prevent spurious detections in vignetting areas
+config.detection.thresholdType ='pixel_stdev'
+
+# This file was inserted from obs_lsst/config/imsim/characterizeImage.py as
+# part of DM-31063. Feel free to modify this file to better reflect the needs
+# of AP; however, when it comes time to permanently remove the obs_* configs,
+# we should check that none of the changes made there since April 12, 2022
+# would be useful here.
+
+# Reduce Chebyshev polynomial order for background fitting (DM-30820)
+config.background.approxOrderX = 1
+config.detection.background.approxOrderX = 1
+config.detection.tempLocalBackground.approxOrderX = 1
+config.detection.tempWideBackground.approxOrderX = 1
+config.repair.cosmicray.background.approxOrderX = 1
+
+# Select candidates for PSF modeling based on S/N threshold (DM-17043 & DM-16785)
+config.measurePsf.starSelector["objectSize"].doFluxLimit = False
+config.measurePsf.starSelector["objectSize"].doSignalToNoiseLimit = True
+
+# S/N cuts for computing aperture corrections to include only objects that
+# were used in the PSF model and have PSF flux S/N greater than the minimum
+# set (DM-23071).
+config.measureApCorr.sourceSelector["science"].doFlags = True
+config.measureApCorr.sourceSelector["science"].doSignalToNoise = True
+config.measureApCorr.sourceSelector["science"].flags.good = ["calib_psf_used"]
+config.measureApCorr.sourceSelector["science"].flags.bad = []
+config.measureApCorr.sourceSelector["science"].signalToNoise.minimum = 150.0
+config.measureApCorr.sourceSelector.name = "science"

--- a/config/LSSTCam-imSim/cmodel.py
+++ b/config/LSSTCam-imSim/cmodel.py
@@ -1,0 +1,32 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os
+import lsst.meas.modelfit
+config.measurement.plugins.names |= ["modelfit_DoubleShapeletPsfApprox", "modelfit_CModel"]
+config.measurement.slots.modelFlux = 'modelfit_CModel'
+config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.985

--- a/config/LSSTCam-imSim/coaddBase.py
+++ b/config/LSSTCam-imSim/coaddBase.py
@@ -1,0 +1,30 @@
+# Configs shared between makeCoaddTempExp and assemble
+
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.matchingKernelSize = 29

--- a/config/LSSTCam-imSim/convolvedFluxes.py
+++ b/config/LSSTCam-imSim/convolvedFluxes.py
@@ -1,0 +1,30 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import lsst.meas.extensions.convolved  # noqa: Load flux.convolved algorithm
+config.plugins.names.add("ext_convolved_ConvolvedFlux")
+config.plugins["ext_convolved_ConvolvedFlux"].seeing.append(8.0)

--- a/config/LSSTCam-imSim/filterMap.py
+++ b/config/LSSTCam-imSim/filterMap.py
@@ -1,0 +1,28 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+config.filterMap = {band: 'lsst_%s_smeared' % (band) for band in 'ugrizy'}

--- a/config/LSSTCam-imSim/gaap.py
+++ b/config/LSSTCam-imSim/gaap.py
@@ -1,0 +1,32 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import lsst.meas.extensions.gaap  # noqa: Load GAaP algorithm
+config.plugins.names.add("ext_gaap_GaapFlux")
+config.plugins["ext_gaap_GaapFlux"].sigmas = [0.5, 0.7, 1.0, 1.5, 2.5, 3.0]
+# Enable PSF photometry after PSF-Gaussianization in the `ext_gaap_GaapFlux` plugin
+config.plugins["ext_gaap_GaapFlux"].doPsfPhotometry = True

--- a/config/LSSTCam-imSim/hsm.py
+++ b/config/LSSTCam-imSim/hsm.py
@@ -1,0 +1,40 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+
+# Enable HSM shapes (unsetup meas_extensions_shapeHSM to disable)
+# 'config' is a SourceMeasurementConfig.
+import os.path
+from lsst.utils import getPackageDir
+
+try:
+    config.load(os.path.join(getPackageDir("meas_extensions_shapeHSM"), "config", "enable.py"))
+    config.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = "deblend_nChild"
+    # Enable debiased moments
+    config.plugins.names |= ["ext_shapeHSM_HsmPsfMomentsDebiased"]
+except LookupError as e:
+    print("Cannot enable shapeHSM (%s): disabling HSM shape measurements" % (e,))

--- a/config/LSSTCam-imSim/kron.py
+++ b/config/LSSTCam-imSim/kron.py
@@ -1,0 +1,29 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import lsst.meas.extensions.photometryKron
+config.plugins.names |= ["ext_photometryKron_KronFlux"]

--- a/config/LSSTCam-imSim/makeWarp.py
+++ b/config/LSSTCam-imSim/makeWarp.py
@@ -1,0 +1,56 @@
+# This file is part of ap_pipe.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+# This file was copied from obs_lsst as part of DM-31063. Feel free to modify
+# this file to better reflect the needs of AP; however, when it comes time to
+# permanently remove the obs_* configs, we should check that none of the
+# changes made there since April 12, 2022 would be useful here.
+
+import os.path
+
+# Load configs shared between assembleCoadd and makeCoaddTempExp
+config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
+
+config.makePsfMatched = True
+config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
+config.modelPsf.defaultFwhm = 7.7
+
+# FUTURE: Set both to True when we decide to run jointcal
+config.doApplyExternalPhotoCalib = False
+config.doApplyExternalSkyWcs = False
+
+# FUTURE: Set to True when we have sky background estimate
+config.doApplySkyCorr = False
+
+# This file was inserted from obs_lsst/config/imsim/makeWarp.py as part of
+# DM-31063. Feel free to modify this file to better reflect the needs of AP;
+# however, when it comes time to permanently remove the obs_* configs, we
+# should check that none of the changes made there since April 12, 2022 would
+# be useful here.
+
+# Set thresholds for PSF fidelity of visit/detector to get included in coadd.
+# These thresholds have been conditioned based on the w_2021_48 processing
+# of the test-med-1 dataset and the w_2021_40 processing of the ~5-yr depth
+# 4431 tract (and considering the HSC thresholds by comparing the metric
+# distributions). See DM-32625 for details.
+config.select.maxEllipResidual = 0.0045
+config.select.maxScaledSizeScatter = 0.006

--- a/config/LSSTCam-imSim/makeWarp.py
+++ b/config/LSSTCam-imSim/makeWarp.py
@@ -27,6 +27,9 @@
 
 import os.path
 
+# HACK: Throw away any changes imposed by obs configs.
+config = type(config)()
+
 # Load configs shared between assembleCoadd and makeCoaddTempExp
 config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
 

--- a/pipelines/DarkEnergyCamera/ProcessCcd.yaml
+++ b/pipelines/DarkEnergyCamera/ProcessCcd.yaml
@@ -8,6 +8,10 @@ imports:
     exclude:
       - isr
 tasks:
+  characterizeImage:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      file: $AP_PIPE_DIR/config/DECam/characterizeImage.py
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:

--- a/pipelines/DarkEnergyCamera/ProcessCcd.yaml
+++ b/pipelines/DarkEnergyCamera/ProcessCcd.yaml
@@ -11,6 +11,9 @@ tasks:
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:
+      file: $AP_PIPE_DIR/config/DECam/calibrate.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
       photoCal.match.referenceSelection.magLimit.fluxField: 'i_flux'
       photoCal.match.referenceSelection.magLimit.maximum: 22.0
 subsets:

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -20,6 +20,18 @@ imports:
       - transformDiaSrcCat
 
 tasks:
+  processVisitFakes:
+  class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
+  config:
+    file: $AP_PIPE_DIR/config/HSC/processCcdWithFakes.py
+    # Do not integrate file and pipeline configs until obs config files are
+    # gone, to make it easier to check for changes on the obs side.
+    # Copy base pipeline's configs, so that they override HSC settings.
+    connections.coaddName: parameters.coaddName
+    insertFakes.doSubSelectSources: True
+    insertFakes.select_col: 'isVisitSource'
+    calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
+    calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -26,7 +26,8 @@ tasks:
     file: $AP_PIPE_DIR/config/HSC/processCcdWithFakes.py
     # Do not integrate file and pipeline configs until obs config files are
     # gone, to make it easier to check for changes on the obs side.
-    # Copy base pipeline's configs, so that they override HSC settings.
+    # Config file wipes out all pre-existing configs, so copy base pipeline
+    # config on top.
     connections.coaddName: parameters.coaddName
     insertFakes.doSubSelectSources: True
     insertFakes.select_col: 'isVisitSource'

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -23,6 +23,21 @@ tasks:
       doApplyExternalPhotoCalib: False
       doApplyExternalSkyWcs: False
       makePsfMatched: True
+  assembleCoadd:
+    class: lsst.pipe.tasks.assembleCoadd.CompareWarpAssembleCoaddTask
+    config:
+      file: $AP_PIPE_DIR/config/HSC/assembleCoadd.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
+      # Copy base pipeline's configs, so that they override HSC settings.
+      doSelectVisits: True
+      doNImage: True
+      assembleStaticSkyModel.doSelectVisits: True
+      connections.outputCoaddName: parameters.coaddName
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.selectedVisits: parameters.selectedVisits
+      connections.coaddExposure: parameters.template
+      # TODO: end DM-30210 workaround
 
 subsets:
 # The singleFrameAp subset is identical to the one in

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -29,7 +29,8 @@ tasks:
       file: $AP_PIPE_DIR/config/HSC/assembleCoadd.py
       # Do not integrate file and pipeline configs until obs config files are
       # gone, to make it easier to check for changes on the obs side.
-      # Copy base pipeline's configs, so that they override HSC settings.
+      # Config file wipes out all pre-existing configs, so copy base pipeline
+      # config on top.
       doSelectVisits: True
       doNImage: True
       assembleStaticSkyModel.doSelectVisits: True

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -11,6 +11,17 @@ imports:
 tasks:
   skyCorr:  # From the HSC DRP-RC2.yaml. Alternative is `doApplySkyCorr: False` in makeWarp
     class: lsst.pipe.drivers.skyCorrection.SkyCorrectionTask
+  makeWarp:
+    class: lsst.pipe.tasks.makeCoaddTempExp.MakeWarpTask
+    config:
+      file: $AP_PIPE_DIR/config/HSC/makeWarp.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
+      # Copy base pipeline's configs, so that they override HSC settings.
+      doWriteEmptyWarps: True
+      doApplyExternalPhotoCalib: False
+      doApplyExternalSkyWcs: False
+      makePsfMatched: True
 
 subsets:
 # The singleFrameAp subset is identical to the one in

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -17,7 +17,8 @@ tasks:
       file: $AP_PIPE_DIR/config/HSC/makeWarp.py
       # Do not integrate file and pipeline configs until obs config files are
       # gone, to make it easier to check for changes on the obs side.
-      # Copy base pipeline's configs, so that they override HSC settings.
+      # Config file wipes out all pre-existing configs, so copy base pipeline
+      # config on top.
       doWriteEmptyWarps: True
       doApplyExternalPhotoCalib: False
       doApplyExternalSkyWcs: False

--- a/pipelines/HyperSuprimeCam/ProcessCcd.yaml
+++ b/pipelines/HyperSuprimeCam/ProcessCcd.yaml
@@ -3,3 +3,10 @@ description: A set of tasks to run when processing raw images, specialized for H
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
+tasks:
+  calibrate:
+    class: lsst.pipe.tasks.calibrate.CalibrateTask
+    config:
+      file: $AP_PIPE_DIR/config/HSC/calibrate.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.

--- a/pipelines/HyperSuprimeCam/ProcessCcd.yaml
+++ b/pipelines/HyperSuprimeCam/ProcessCcd.yaml
@@ -4,6 +4,12 @@ instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 tasks:
+  characterizeImage:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      file: $AP_PIPE_DIR/config/HSC/characterizeImage.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -15,7 +15,8 @@ tasks:
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/makeWarp.py
       # Do not integrate file and pipeline configs until obs config files are
       # gone, to make it easier to check for changes on the obs side.
-      # Copy base pipeline's configs, so that they override Imsim settings.
+      # Config file wipes out all pre-existing configs, so copy base pipeline
+      # config on top.
       doWriteEmptyWarps: True
       doApplyExternalPhotoCalib: False
       doApplyExternalSkyWcs: False

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -21,6 +21,21 @@ tasks:
       doApplyExternalPhotoCalib: False
       doApplyExternalSkyWcs: False
       makePsfMatched: True
+  assembleCoadd:
+    class: lsst.pipe.tasks.assembleCoadd.CompareWarpAssembleCoaddTask
+    config:
+      file: $AP_PIPE_DIR/config/LSSTCam-imSim/assembleCoadd.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
+      # Copy base pipeline's configs, so that they override Imsim settings.
+      doSelectVisits: True
+      doNImage: True
+      assembleStaticSkyModel.doSelectVisits: True
+      connections.outputCoaddName: parameters.coaddName
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.selectedVisits: parameters.selectedVisits
+      connections.coaddExposure: parameters.template
+      # TODO: end DM-30210 workaround
 
 subsets:
 # The singleFrameAp subset is identical to the one in

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -27,7 +27,8 @@ tasks:
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/assembleCoadd.py
       # Do not integrate file and pipeline configs until obs config files are
       # gone, to make it easier to check for changes on the obs side.
-      # Copy base pipeline's configs, so that they override Imsim settings.
+      # Config file wipes out all pre-existing configs, so copy base pipeline
+      # config on top.
       doSelectVisits: True
       doNImage: True
       assembleStaticSkyModel.doSelectVisits: True

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -8,6 +8,19 @@ imports:
     exclude:  # These tasks come from LsstCamImSim/ProcessCcd.yaml instead
       - processCcd
 
+tasks:
+  makeWarp:
+    class: lsst.pipe.tasks.makeCoaddTempExp.MakeWarpTask
+    config:
+      file: $AP_PIPE_DIR/config/LSSTCam-imSim/makeWarp.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
+      # Copy base pipeline's configs, so that they override Imsim settings.
+      doWriteEmptyWarps: True
+      doApplyExternalPhotoCalib: False
+      doApplyExternalSkyWcs: False
+      makePsfMatched: True
+
 subsets:
 # The singleFrameAp subset is identical to the one in
 # $AP_PIPE_DIR/pipelines/ApTemplate.yaml, but needs to be defined here because

--- a/pipelines/LsstCamImSim/ProcessCcd.yaml
+++ b/pipelines/LsstCamImSim/ProcessCcd.yaml
@@ -13,6 +13,9 @@ tasks:
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:
+      file: $AP_PIPE_DIR/config/LSSTCam-imSim/calibrate.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
       connections.astromRefCat: 'cal_ref_cat_2_2'
       connections.photoRefCat: 'cal_ref_cat_2_2'
       astromRefObjLoader.ref_dataset_name: 'cal_ref_cat_2_2'

--- a/pipelines/LsstCamImSim/ProcessCcd.yaml
+++ b/pipelines/LsstCamImSim/ProcessCcd.yaml
@@ -10,6 +10,12 @@ tasks:
       connections.newBFKernel: bfk
       doDefect: False
       doBrighterFatter: True
+  characterizeImage:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      file: $AP_PIPE_DIR/config/LsstCam-imSim/characterizeImage.py
+      # Do not integrate file and pipeline configs until obs config files are
+      # gone, to make it easier to check for changes on the obs side.
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:


### PR DESCRIPTION
This PR switches the AP pipelines from using local config files rather than the ones in `obs_subaru`, `obs_decam`, and `obs_lsst`. This change will allow the AP configs to diverge from the DRP ones, though determining the best settings for AP is outside the scope of this work.

To make it easier in the future to test for *unintentional* divergence from the obs packages, the configurations have all been left in Python config files, with no effort made to integrate settings into the pipelines.

In the case of ImSim, some of the AP configs combine pairs of "LSST" and "ImSim" files into a single config file. The sections originating from either config are clearly marked.