### PR TITLE
DM-34480: Update unit test for changes in APDB configuration

### DIFF
--- a/tests/test_makeapdb.py
+++ b/tests/test_makeapdb.py
@@ -79,14 +79,6 @@ class MakeApdbParserTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(parsed.config.db_url, 'dummy')
         self.assertEqual(parsed.config.dia_object_index, 'pix_id_iov')
 
-    def testDiaPipeDefaults(self):
-        """Verify that DiaPipelineTask's custom APDB settings are included.
-        """
-        args = '-c db_url="dummy"'
-        parsed = self._parseString(args)
-        # Allow ap_association or AP_ASSOCIATION.
-        self.assertRegex(parsed.config.extra_schema_file, "(?i)ap_association")
-
     @contextlib.contextmanager
     def _temporaryBuffer(self):
         tempStdErr = io.StringIO()


### PR DESCRIPTION
Dropped one unit test, `extra_schema_file` is deprecated, no need to test its value.