### PR TITLE
DM-32694: Split AP pipeline into ApPipeWithFakes

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -14,25 +14,11 @@ imports:
 parameters:
   # Pipeline configurable to run on both goodSeeing and deep templates, depending on dataset.
   coaddName: goodSeeing
-  # TODO: redundant connection definitions workaround for DM-30210
-  template: goodSeeingCoadd
-  diaSrcCat: goodSeeingDiff_diaSrc
-  diaSrcSchema: goodSeeingDiff_diaSrc_schema
-  diaSrcParquet: goodSeeingDiff_diaSrcTable
-  diff: goodSeeingDiff_differenceExp
-  diffScore: goodSeeingDiff_scoreExp
-  diffWarp: goodSeeingDiff_warpedExp
-  diffMatch: goodSeeingDiff_matchedExp
-  assocSrc: goodSeeingDiff_assocDiaSrc
-  templateExp: goodSeeingDiff_templateExp
-  # TODO: end DM-30210 workaround
 tasks:
   retrieveTemplate:  # For multi-tract difference imaging
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.coaddExposures: parameters.template
-      connections.outputExposure: parameters.templateExp
   imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
@@ -40,38 +26,15 @@ tasks:
       doSkySources: True
       coaddName: parameters.coaddName  # Can be removed once ImageDifference no longer supports Gen 2
       connections.coaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.coaddExposures: parameters.template
-      connections.dcrCoadds: dcrCoadd
-      connections.outputSchema: parameters.diaSrcSchema
-      connections.subtractedExposure: parameters.diff
-      connections.scoreExposure: parameters.diffScore
-      connections.warpedExposure: parameters.diffWarp
-      connections.matchedExposure: parameters.diffMatch
-      connections.diaSources: parameters.diaSrcCat
-      connections.inputTemplate: parameters.templateExp
-      # TODO: end DM-30210 workaround
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.diaSourceSchema: parameters.diaSrcSchema
-      connections.diaSourceCat: parameters.diaSrcCat
-      connections.diffIm: parameters.diff
-      connections.diaSourceTable: parameters.diaSrcParquet
-      # TODO: end DM-30210 workaround
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       connections.coaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.diaSourceTable: parameters.diaSrcParquet
-      connections.diffIm: parameters.diff
-      connections.warpedExposure: parameters.diffWarp
-      connections.associatedDiaSources: parameters.assocSrc
-      # TODO: end DM-30210 workaround
 subsets:
   apPipe:
     subset:
@@ -92,9 +55,16 @@ contracts:
   - imageDifference.doWriteSubtractedExp is True
   - imageDifference.doSkySources == transformDiaSrcCat.doRemoveSkySources
   # Inputs and outputs must match
-  - retrieveTemplate.connections.outputExposure == imageDifference.connections.inputTemplate
-  - imageDifference.connections.coaddName == transformDiaSrcCat.connections.coaddName
-  - imageDifference.connections.fakesType == transformDiaSrcCat.connections.fakesType
-  - imageDifference.connections.coaddName == diaPipe.connections.coaddName
-  - imageDifference.connections.fakesType == diaPipe.connections.fakesType
-  - transformDiaSrcCat.connections.diaSourceTable == diaPipe.connections.diaSourceTable
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).outputExposure.name ==
+      imageDifference.connections.ConnectionsClass(config=imageDifference).inputTemplate.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+        diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).warpedExposure.name ==
+        diaPipe.connections.ConnectionsClass(config=diaPipe).warpedExposure.name
+  - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+        diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -66,5 +66,7 @@ contracts:
         diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
   - imageDifference.connections.ConnectionsClass(config=imageDifference).warpedExposure.name ==
         diaPipe.connections.ConnectionsClass(config=diaPipe).warpedExposure.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
   - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
         diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -7,22 +7,12 @@ imports:
 parameters:
   coaddName: goodSeeing
   fakesType: 'fakes_'
-  # TODO: redundant connection definitions workaround for DM-30210
-  template: fakes_goodSeeingCoadd
-  diaSrcCat: fakes_goodSeeingDiff_diaSrc
-  diaSrcSchema: fakes_goodSeeingDiff_diaSrc_schema
-  diaSrcParquet: fakes_goodSeeingDiff_diaSrcTable
-  diff: fakes_goodSeeingDiff_differenceExp
-  diffScore: fakes_goodSeeingDiff_scoreExp
-  diffWarp: fakes_goodSeeingDiff_warpedExp
-  diffMatch: fakes_goodSeeingDiff_matchedExp
-  assocSrc: fakes_goodSeeingDiff_assocDiaSrc
-  templateExp: fakes_goodSeeingDiff_templateExp
 
 tasks:
   createFakes:
     class: lsst.ap.pipe.createApFakes.CreateRandomApFakesTask
     config:
+      connections.fakesType: parameters.fakesType
       magMin: 20
       magMax: 26
       fraction: 0
@@ -31,21 +21,26 @@ tasks:
     class: lsst.pipe.tasks.insertFakes.InsertFakesTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
       doSubSelectSources: True
       select_col: 'isTemplateSource'
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: 'isVisitSource'
       calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
       calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
+  retrieveTemplate:
+    class: lsst.ip.diffim.getTemplate.GetTemplateTask
+    config:
+      connections.fakesType: parameters.fakesType
   imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       connections.fakesType: parameters.fakesType
-      connections.exposure: fakes_calexp
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
@@ -60,16 +55,24 @@ tasks:
     class: lsst.pipe.tasks.matchFakes.MatchFakesTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
       matchDistanceArcseconds: 0.5
 
 contracts:
-  - createFakes.connections.fakesType == coaddFakes.connections.fakesType
-  - createFakes.connections.fakesType == processVisitFakes.connections.fakesType
-  - createFakes.connections.fakesType == imageDifference.connections.fakesType
-  - createFakes.connections.fakesType == diaPipe.connections.fakesType
-  - createFakes.connections.fakesType == fakesMatch.connections.fakesType
-  - coaddFakes.connections.coaddName == processVisitFakes.connections.coaddName
-  - coaddFakes.connections.coaddName == imageDifference.connections.coaddName
-  - coaddFakes.connections.coaddName == diaPipe.connections.coaddName
-  - coaddFakes.connections.coaddName == fakesMatch.connections.coaddName
-  - retrieveTemplate.connections.outputExposure == imageDifference.connections.inputTemplate
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
+  - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
+      retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).coaddExposures.name
+  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
+      imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
+  - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
+  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).outputExposure.name ==
+      imageDifference.connections.ConnectionsClass(config=imageDifference).inputTemplate.name

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -1,6 +1,10 @@
 description: AP Pipeline with synthetic/fake sources. Templates are inputs.
 # This pipeline is imported by camera-specific pipelines.
 # You almost certainly want to run one of those, and not this one.
+#
+# All tasks that take fake sources as input have the word "Fakes" in the label.
+# This is for disambiguation and forward-compatibility with parallel tasks that
+# use unmodified inputs, either here or in ap_verify.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
@@ -33,12 +37,12 @@ tasks:
       insertFakes.select_col: 'isVisitSource'
       calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
       calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
-  retrieveTemplate:
+  retrieveTemplateWithFakes:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-  imageDifference:
+  imageDifferenceWithFakes:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       connections.coaddName: parameters.coaddName
@@ -46,7 +50,7 @@ tasks:
       connections.fakesType: parameters.fakesType
       doWriteWarpedExp: True             # Required for packaging alerts in diaPipe
       doSkySources: True
-  transformDiaSrcCat:
+  transformDiaSrcCatWithFakes:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
@@ -67,25 +71,30 @@ tasks:
       matchDistanceArcseconds: 0.5
 subsets:
   # processCcd imported unchanged from ProcessCcd.yaml
-  apPipe:
+  prepareFakes:
     subset:
-      - isr
-      - characterizeImage
-      - calibrate
-      - retrieveTemplate
-      - imageDifference
-      - transformDiaSrcCat
-      - diaPipe
+      - createFakes
+      - coaddFakes
     description: >
-      An alias of ApPipe to use in higher-level pipelines.
+      Creation of fake sources.
+  apPipeWithFakes:
+    subset:
+      - processVisitFakes
+      - retrieveTemplateWithFakes
+      - imageDifferenceWithFakes
+      - transformDiaSrcCatWithFakes
+      - diaPipe
+      - fakesMatch
+    description: >
+      The AP pipeline with fakes. Requires apPipe and prepareFakes subsets.
 
 contracts:
   # DiaPipelineTask needs diaSource fluxes, catalogs, warped exposures, and difference exposures
-  - imageDifference.doMeasurement is True
-  - imageDifference.doWriteSources is True
-  - imageDifference.doWriteWarpedExp is True
-  - imageDifference.doWriteSubtractedExp is True
-  - imageDifference.doSkySources == transformDiaSrcCat.doRemoveSkySources
+  - imageDifferenceWithFakes.doMeasurement is True
+  - imageDifferenceWithFakes.doWriteSources is True
+  - imageDifferenceWithFakes.doWriteWarpedExp is True
+  - imageDifferenceWithFakes.doWriteSubtractedExp is True
+  - imageDifferenceWithFakes.doSkySources == transformDiaSrcCatWithFakes.doRemoveSkySources
   # Inputs and outputs must match.
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
@@ -93,24 +102,24 @@ contracts:
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
   - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
-      retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).coaddExposures.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).subtractedExposure.name ==
+      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diffIm.name
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).diaSources.name ==
+      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceCat.name
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).subtractedExposure.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).warpedExposure.name ==
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).warpedExposure.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).warpedExposure.name
-  - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+  - transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceTable.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
   - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
-      imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name
+      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).exposure.name
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).subtractedExposure.name ==
       fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
   - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
       fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
-  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).outputExposure.name ==
-      imageDifference.connections.ConnectionsClass(config=imageDifference).inputTemplate.name
+  - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).outputExposure.name ==
+      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).inputTemplate.name

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -111,6 +111,8 @@ contracts:
       diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
   - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).warpedExposure.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).warpedExposure.name
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).exposure.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
   - transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceTable.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
   - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -64,7 +64,7 @@ tasks:
       connections.fakesType: parameters.fakesType
       # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
   fakesMatch:
-    class: lsst.pipe.tasks.matchFakes.MatchFakesTask
+    class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -8,7 +8,7 @@ parameters:
   coaddName: goodSeeing
   fakesType: 'fakes_'
   # TODO: redundant connection definitions workaround for DM-30210
-  template: goodSeeingCoadd
+  template: fakes_goodSeeingCoadd
   diaSrcCat: fakes_goodSeeingDiff_diaSrc
   diaSrcSchema: fakes_goodSeeingDiff_diaSrc_schema
   diaSrcParquet: fakes_goodSeeingDiff_diaSrcTable

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -3,7 +3,7 @@ description: AP Pipeline with synthetic/fake sources. Templates are inputs.
 # You almost certainly want to run one of those, and not this one.
 
 imports:
-  - location: $AP_PIPE_DIR/pipelines/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 parameters:
   coaddName: goodSeeing
   fakesType: 'fakes_'
@@ -36,19 +36,27 @@ tasks:
   retrieveTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
+      connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
   imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
+      connections.coaddName: parameters.coaddName
+      coaddName: parameters.coaddName  # Can be removed once ImageDifference no longer supports Gen 2
       connections.fakesType: parameters.fakesType
+      doWriteWarpedExp: True             # Required for packaging alerts in diaPipe
+      doSkySources: True
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
+      connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      doRemoveSkySources: True
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doWriteAssociatedSources: True
+      connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
   fakesMatch:
@@ -57,8 +65,28 @@ tasks:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       matchDistanceArcseconds: 0.5
+subsets:
+  # processCcd imported unchanged from ProcessCcd.yaml
+  apPipe:
+    subset:
+      - isr
+      - characterizeImage
+      - calibrate
+      - retrieveTemplate
+      - imageDifference
+      - transformDiaSrcCat
+      - diaPipe
+    description: >
+      An alias of ApPipe to use in higher-level pipelines.
 
 contracts:
+  # DiaPipelineTask needs diaSource fluxes, catalogs, warped exposures, and difference exposures
+  - imageDifference.doMeasurement is True
+  - imageDifference.doWriteSources is True
+  - imageDifference.doWriteWarpedExp is True
+  - imageDifference.doWriteSubtractedExp is True
+  - imageDifference.doSkySources == transformDiaSrcCat.doRemoveSkySources
+  # Inputs and outputs must match.
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
@@ -66,6 +94,16 @@ contracts:
       processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
   - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
       retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).coaddExposures.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).warpedExposure.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).warpedExposure.name
+  - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
   - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
       imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==

--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -50,5 +50,15 @@ contracts:
   - makeWarp.makeDirect is True
   - makeWarp.makePsfMatched is True
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - calibrate.connections.outputExposure ==
+      consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).calexp.name
+  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
+      selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).visitSummaries.name
+  - calibrate.connections.outputExposure ==
+      makeWarp.connections.ConnectionsClass(config=makeWarp).calExpList.name
+  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
+      makeWarp.connections.ConnectionsClass(config=makeWarp).visitSummary.name
   - selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).goodVisits.name ==
       assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).selectedVisits.name
+  - makeWarp.connections.ConnectionsClass(config=makeWarp).psfMatched.name ==
+      assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).psfMatchedWarps.name

--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -6,19 +6,12 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 parameters:
   coaddName: goodSeeing
-  # TODO: redundant connection definitions workaround for DM-30210
-  selectedVisits: goodSeeingVisits
-  template: goodSeeingCoadd
-  # TODO: end DM-30210 workaround
 tasks:
   consolidateVisitSummary: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
   selectGoodSeeingVisits:
     class: lsst.pipe.tasks.selectImages.BestSeeingQuantileSelectVisitsTask
     config:
       connections.coaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.goodVisits: parameters.selectedVisits
-      # TODO: end DM-30210 workaround
   makeWarp:
     class: lsst.pipe.tasks.makeCoaddTempExp.MakeWarpTask
     config:
@@ -33,10 +26,6 @@ tasks:
       doNImage: True
       assembleStaticSkyModel.doSelectVisits: True
       connections.outputCoaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.selectedVisits: parameters.selectedVisits
-      connections.coaddExposure: parameters.template
-      # TODO: end DM-30210 workaround
 
 subsets:
   singleFrameAp:
@@ -60,4 +49,6 @@ subsets:
 contracts:
   - makeWarp.makeDirect is True
   - makeWarp.makePsfMatched is True
-  - selectGoodSeeingVisits.connections.goodVisits == assembleCoadd.connections.selectedVisits
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).goodVisits.name ==
+      assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).selectedVisits.name

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -35,10 +35,6 @@ tasks:
       doNImage: True
       assembleStaticSkyModel.doSelectVisits: True
       connections.outputCoaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.selectedVisits: parameters.selectedVisits
-      connections.coaddExposure: parameters.template
-      # TODO: end DM-30210 workaround
 
 subsets:
 # The singleFrameAp subset is identical to the one in

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -33,10 +33,6 @@ tasks:
       doNImage: True
       assembleStaticSkyModel.doSelectVisits: True
       connections.outputCoaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.selectedVisits: parameters.selectedVisits
-      connections.coaddExposure: parameters.template
-      # TODO: end DM-30210 workaround
 
 subsets:
 # The singleFrameAp subset is identical to the one in


### PR DESCRIPTION
This PR significantly reworks the AP pipelines, making two major changes:

- the [DM-30210](https://jira.lsstcorp.org/browse/DM-30210) workarounds are now done at the contract level, not the parameter/config level. This arrangement is harder to read, but is much more portable to importing pipelines.
- the `ApPipeWithFakes` pipeline no longer imports `ApPipe`, giving it independent task labels and contracts. This change is strictly for the benefit of `ap_verify` (which needs to be careful about distinguishing fakes and non-fakes tasks), and does not improve `ap_pipe` itself.