### PR TITLE
DM-34698: Remove config overrides setting kernelSize to 25

### DIFF
--- a/pipelines/DarkEnergyCamera/ProcessCcd.yaml
+++ b/pipelines/DarkEnergyCamera/ProcessCcd.yaml
@@ -14,9 +14,6 @@ tasks:
       file: $AP_PIPE_DIR/config/DECam/characterizeImage.py
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
-      python: |
-        config.measurePsf.makePsfCandidates.kernelSize = 25
-        config.measurePsf.psfDeterminer["piff"].kernelSize = 25
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:

--- a/pipelines/HyperSuprimeCam/ProcessCcd.yaml
+++ b/pipelines/HyperSuprimeCam/ProcessCcd.yaml
@@ -12,9 +12,6 @@ tasks:
       # gone, to make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
-      python: |
-        config.measurePsf.makePsfCandidates.kernelSize = 25
-        config.measurePsf.psfDeterminer["piff"].kernelSize = 25
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:

--- a/pipelines/LsstCamImSim/ProcessCcd.yaml
+++ b/pipelines/LsstCamImSim/ProcessCcd.yaml
@@ -18,9 +18,6 @@ tasks:
       # gone, to make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
-      python: |
-        config.measurePsf.makePsfCandidates.kernelSize = 25
-        config.measurePsf.psfDeterminer["piff"].kernelSize = 25
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:

--- a/pipelines/ProcessCcd.yaml
+++ b/pipelines/ProcessCcd.yaml
@@ -1,13 +1,7 @@
 description: ProcessCcd - A set of tasks to run when processing raw images.
 tasks:
   isr: lsst.ip.isr.IsrTask
-  characterizeImage:
-    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
-    # We want a larger psf kernel, to include the calibFlux 12 pixel radius.
-    config:
-      python: |
-        config.measurePsf.makePsfCandidates.kernelSize = 25
-        config.measurePsf.psfDeterminer["piff"].kernelSize = 25
+  characterizeImage: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
   calibrate: lsst.pipe.tasks.calibrate.CalibrateTask
 subsets:
   processCcd:


### PR DESCRIPTION
These were explicitly set to 25 when drp_pipe wanted kernelSize to be 21
during their validation. Now that the default is switched to 25, these
overrides are no longer required.