### PR TITLE
DM-35359: Set doApplyFinalizedPsf to False for all AP makeWarp steps, for reals

### DIFF
--- a/config/HSC/makeWarp.py
+++ b/config/HSC/makeWarp.py
@@ -18,3 +18,6 @@ config.modelPsf.defaultFwhm = 7.7
 config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
 config.warpAndPsfMatch.warp.warpingKernelName = 'lanczos5'
 config.coaddPsf.warpingKernelName = 'lanczos5'
+
+# This is properly configured in ApTemplate.yaml, but must also be here for now
+config.doApplyFinalizedPsf = False

--- a/config/LSSTCam-imSim/makeWarp.py
+++ b/config/LSSTCam-imSim/makeWarp.py
@@ -44,6 +44,9 @@ config.doApplyExternalSkyWcs = False
 # FUTURE: Set to True when we have sky background estimate
 config.doApplySkyCorr = False
 
+# This is properly configured in ApTemplate.yaml, but must also be here for now
+config.doApplyFinalizedPsf = False
+
 # This file was inserted from obs_lsst/config/imsim/makeWarp.py as part of
 # DM-31063. Feel free to modify this file to better reflect the needs of AP;
 # however, when it comes time to permanently remove the obs_* configs, we

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -9,6 +9,12 @@ description: End to end Alert Production pipeline
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
 # -c diaPipe:apdb.connection_timeout: 240
 
+# WARNING: camera-specific pipelines importing this pipeline may
+# blow away all the configs that are set in this file.
+# To update a pipeline config prior to DM-35504, you MUST put it in either,
+# e.g., $AP_PIPE_DIR/config/$CAMERA/someTask.py, or in a camera-specific,
+# pipeline, e.g., $AP_PIPE_DIR/pipelines/$CAMERA/ApPipe.yaml.
+
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 parameters:

--- a/pipelines/ApPipeWithFakes.yaml
+++ b/pipelines/ApPipeWithFakes.yaml
@@ -6,6 +6,12 @@ description: AP Pipeline with synthetic/fake sources. Templates are inputs.
 # This is for disambiguation and forward-compatibility with parallel tasks that
 # use unmodified inputs, either here or in ap_verify.
 
+# WARNING: some camera-specific pipelines importing this pipeline presently
+# blow away all the configs that are set in this file.
+# To update a pipeline config prior to DM-35504, you MUST put it in either,
+# e.g., $AP_PIPE_DIR/config/$CAMERA/someTask.py, or in a camera-specific,
+# pipeline, e.g., $AP_PIPE_DIR/pipelines/$CAMERA/ApPipeWithFakes.yaml.
+
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 parameters:

--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -2,6 +2,12 @@ description: The AP template building pipeline
 # Look in subdirectories of $AP_PIPE_DIR/pipelines to find customized pipelines
 # for each camera. Those pipelines import this general template-building pipeline.
 
+# WARNING: some camera-specific pipelines importing this pipeline presently
+# blow away all the configs that are set in this file.
+# To update a pipeline config prior to DM-35504, you MUST put it in either,
+# e.g., $AP_PIPE_DIR/config/$CAMERA/someTask.py, or in a camera-specific,
+# pipeline, e.g., $AP_PIPE_DIR/pipelines/$CAMERA/ApTemplate.yaml.
+
 imports:
   - location: $AP_PIPE_DIR/pipelines/ProcessCcd.yaml
 parameters:

--- a/pipelines/ProcessCcd.yaml
+++ b/pipelines/ProcessCcd.yaml
@@ -1,4 +1,11 @@
 description: ProcessCcd - A set of tasks to run when processing raw images.
+
+# WARNING: some camera-specific pipelines importing this pipeline presently
+# blow away all the configs that are set in this file.
+# To update a pipeline config prior to DM-35504, you MUST put it in either,
+# e.g., $AP_PIPE_DIR/config/$CAMERA/someTask.py, or in a camera-specific,
+# pipeline, e.g., $AP_PIPE_DIR/pipelines/$CAMERA/ProcessCcd.yaml.
+
 tasks:
   isr: lsst.ip.isr.IsrTask
   characterizeImage: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask


### PR DESCRIPTION
This PR adds a config to the imSim and HSC camera-specific makeWarp config files.