### PR TITLE
DM-34711: Reprocess HSC Cosmos dataset with Fakes

### DIFF
--- a/config/DECam/processCcdWithFakes.py
+++ b/config/DECam/processCcdWithFakes.py
@@ -1,0 +1,34 @@
+# This file is modeled after HSC's, and has all of the minimal DECam-specific
+# calibrate configs. Since processCcdWithFakesTask uses a minimal version of
+# calibrateTask, we can't import the whole thing, because it configs for
+# astrometry and photometry; these are turned off in processCcdWithFakes.
+
+import os.path
+
+from lsst.meas.algorithms import ColorLimit
+from lsst.meas.astrom import MatchOptimisticBConfig
+
+# HACK: Throw away any changes imposed by obs configs, especially plugins.
+config.loadFromString(type(config)().saveToString())
+
+obsConfigDir = os.path.join(os.path.dirname(__file__))
+
+# Set to match defaults currently used in HSC production runs (e.g. S15B+)
+config.calibrate.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+config.calibrate.doWriteMatchesDenormalized = True
+
+# Detection
+# This config matches obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.calibrate.detection.isotropicGrow = True
+
+config.calibrate.measurement.load(os.path.join(obsConfigDir, "apertures.py"))
+
+# Deblender
+# These configs match obs_subaru, to facilitate 1:1 comparisons between DECam and HSC
+config.calibrate.deblend.maxFootprintSize = 0
+config.calibrate.deblend.maskLimits["NO_DATA"] = 0.25  # Ignore sources that are in the vignetted region
+config.calibrate.deblend.maxFootprintArea = 10000
+
+config.calibrate.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.263

--- a/config/HSC/calibrate.py
+++ b/config/HSC/calibrate.py
@@ -19,6 +19,9 @@ bgFile = os.path.join(ObsConfigDir, "background.py")
 config.detection.background.load(bgFile)
 
 # Reference catalogs
+# TODO: remove this section once DM-27858 is resolved
+# (note that as of DM-27013, we adopted Gaia DR2 as the default astrometric,
+# reference catalog, and this config block overrides that to use PS1 instead)
 for refObjLoader in (config.astromRefObjLoader,
                      config.photoRefObjLoader,
                      ):
@@ -27,7 +30,6 @@ for refObjLoader in (config.astromRefObjLoader,
     refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
     # Use the filterMap instead of the "any" filter.
     refObjLoader.anyFilterMapsToThis = None
-
 # These are the Gen3 configuration options for reference catalog name.
 config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
 config.connections.astromRefCat = "ps1_pv3_3pi_20170110"
@@ -50,7 +52,7 @@ for matchConfig in (config.astrometry,
         matchConfig.matcher.maxMatchDistArcSec = 2.0
         matchConfig.sourceSelector.active.excludePixelFlags = False
 
-# Set to match defaults curretnly used in HSC production runs (e.g. S15B)
+# Set to match defaults currently used in HSC production runs (e.g. S15B)
 config.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
 
 config.photoCal.applyColorTerms = True

--- a/config/HSC/processCcdWithFakes.py
+++ b/config/HSC/processCcdWithFakes.py
@@ -9,5 +9,31 @@ import os.path
 config.loadFromString(type(config)().saveToString())
 
 ObsConfigDir = os.path.dirname(__file__)
-calFile = os.path.join(ObsConfigDir, "calibrate.py")
-config.calibrate.load(calFile)
+
+# The following configs are copied from `ap_pipe/config/HSC/calibrate.py`
+# We do not import the full file directly because only a minimal form of
+# calibrateTask is used during `processCcdWithFakesTask`.
+
+bgFile = os.path.join(ObsConfigDir, "background.py")
+
+# Cosmic rays and background estimation
+config.calibrate.detection.background.load(bgFile)
+
+# Set to match defaults currently used in HSC production runs (e.g. S15B)
+config.calibrate.catalogCalculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.95
+
+config.calibrate.doWriteMatchesDenormalized = True
+
+# Detection
+config.calibrate.detection.isotropicGrow = True
+
+config.calibrate.measurement.load(os.path.join(ObsConfigDir, "apertures.py"))
+
+# Deblender
+config.calibrate.deblend.maxFootprintSize = 0
+# Ignore sources that are in the vignetted region
+config.calibrate.deblend.maskLimits["NO_DATA"] = 0.25
+config.calibrate.deblend.maxFootprintArea = 10000
+
+config.calibrate.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.168


### PR DESCRIPTION
This PR fixes some HSC configs that caused an error when running ApPipeWithFakes. The task injects fakes to visits is sneaky because it calls calibrateTask a second time with most things (like astrometry and photometry) turned off. The PR also adds a config file for DECam so its visit-level fakes injection properly picks up camera-specific calibrateTask configs too.