### PR TITLE
DM-30869: Modernize MetricTask for better Gen 3 workflow

### DIFF
--- a/python/lsst/ap/pipe/metrics.py
+++ b/python/lsst/ap/pipe/metrics.py
@@ -90,20 +90,18 @@ class ApFakesCompletenessMetricTask(MetricTask):
     ConfigClass = ApFakesCompletenessMetricConfig
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        try:
-            inputs = butlerQC.get(inputRefs)
-            inputs["band"] = butlerQC.quantum.dataId["band"]
-            outputs = self.run(**inputs)
-            if outputs.measurement is not None:
-                butlerQC.put(outputs, outputRefs)
-            else:
-                self.log.debug("Skipping measurement of %r on %s "
-                               "as not applicable.", self, inputRefs)
-        except MetricComputationError:
-            # Apparently lsst.log doesn't have built-in exception support?
-            self.log.error(
-                "Measurement of %r failed on %s->%s",
-                self, inputRefs, outputRefs, exc_info=True)
+        """Do Butler I/O to provide in-memory objects for run.
+
+        This specialization of runQuantum passes the band ID to `run`.
+        """
+        inputs = butlerQC.get(inputRefs)
+        inputs["band"] = butlerQC.quantum.dataId["band"]
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debug("Skipping measurement of %r on %s "
+                           "as not applicable.", self, inputRefs)
 
     def run(self, matchedFakes, band):
         """Compute the completeness of recovered fakes within a magnitude

--- a/python/lsst/ap/pipe/metrics.py
+++ b/python/lsst/ap/pipe/metrics.py
@@ -115,7 +115,7 @@ class ApFakesCompletenessMetricTask(MetricTask):
             Catalog of fakes that were inserted into the ccdExposure matched
             to their detected counterparts.
         band : `str`
-            Single character name of the observed band for this quanta.
+            Name of the band whose magnitudes are to be analyzed.
 
         Returns
         -------

--- a/python/lsst/ap/pipe/metrics.py
+++ b/python/lsst/ap/pipe/metrics.py
@@ -111,7 +111,7 @@ class ApFakesCompletenessMetricTask(MetricTask):
 
         Parameters
         ----------
-        matchedFakes : `lsst.afw.table.SourceCatalog` or `None`
+        matchedFakes : `lsst.afw.table.SourceCatalog`
             Catalog of fakes that were inserted into the ccdExposure matched
             to their detected counterparts.
         band : `str`
@@ -124,22 +124,18 @@ class ApFakesCompletenessMetricTask(MetricTask):
             ``measurement``
                 the ratio (`lsst.verify.Measurement` or `None`)
         """
-        if matchedFakes is not None:
-            magnitudes = np.fabs(matchedFakes[f"{self.config.mag_col}" % band])
-            magCutFakes = matchedFakes[np.logical_and(magnitudes > self.config.magMin,
-                                                      magnitudes < self.config.magMax)]
-            if len(magCutFakes) <= 0.0:
-                raise MetricComputationError(
-                    "No matched fakes catalog sources found; Completeness is "
-                    "ill defined.")
-            else:
-                meas = Measurement(
-                    self.config.metricName,
-                    ((magCutFakes["diaSourceId"] > 0).sum() / len(magCutFakes))
-                    * u.dimensionless_unscaled)
+        magnitudes = np.fabs(matchedFakes[f"{self.config.mag_col}" % band])
+        magCutFakes = matchedFakes[np.logical_and(magnitudes > self.config.magMin,
+                                                  magnitudes < self.config.magMax)]
+        if len(magCutFakes) <= 0.0:
+            raise MetricComputationError(
+                "No matched fakes catalog sources found; Completeness is "
+                "ill defined.")
         else:
-            self.log.info("Nothing to do: no matched catalog found.")
-            meas = None
+            meas = Measurement(
+                self.config.metricName,
+                ((magCutFakes["diaSourceId"] > 0).sum() / len(magCutFakes))
+                * u.dimensionless_unscaled)
         return Struct(measurement=meas)
 
 
@@ -174,7 +170,7 @@ class ApFakesCountMetricTask(ApFakesCompletenessMetricTask):
 
         Parameters
         ----------
-        matchedFakes : `lsst.afw.table.SourceCatalog` or `None`
+        matchedFakes : `lsst.afw.table.SourceCatalog`
             Catalog of fakes that were inserted into the ccdExposure matched
             to their detected counterparts.
         band : `str`
@@ -187,13 +183,9 @@ class ApFakesCountMetricTask(ApFakesCompletenessMetricTask):
             ``measurement``
                 the ratio (`lsst.verify.Measurement` or `None`)
         """
-        if matchedFakes is not None:
-            magnitudes = np.fabs(matchedFakes[f"{self.config.mag_col}" % band])
-            magCutFakes = matchedFakes[np.logical_and(magnitudes > self.config.magMin,
-                                                      magnitudes < self.config.magMax)]
-            meas = Measurement(self.config.metricName,
-                               len(magCutFakes) * u.count)
-        else:
-            self.log.info("Nothing to do: no matched catalog supplied.")
-            meas = None
+        magnitudes = np.fabs(matchedFakes[f"{self.config.mag_col}" % band])
+        magCutFakes = matchedFakes[np.logical_and(magnitudes > self.config.magMin,
+                                                  magnitudes < self.config.magMax)]
+        meas = Measurement(self.config.metricName,
+                           len(magCutFakes) * u.count)
         return Struct(measurement=meas)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -100,14 +100,6 @@ class TestApCompletenessTask(MetricTaskTestCase):
             ((self.expectedAllMatched / self.targetSources) * u.dimensionless_unscaled).value,
             places=2)
 
-    def testMissingData(self):
-        """Test the run method with no data.
-        """
-        result = self.task.run(None, None)
-        testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
     def testValidEmpty(self):
         """Test the run method with a valid but zero result.
         """
@@ -184,14 +176,6 @@ class TestApCountTask(MetricTaskTestCase):
             meas.quantity.value,
             (self.expectedAllMatched * u.count).value,
             places=2)
-
-    def testMissingData(self):
-        """Test the run method with no data.
-        """
-        result = self.task.run(None, None)
-        testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
 
     def testValidEmpty(self):
         """Test the run method with a valid but zero result.


### PR DESCRIPTION
This PR removes all code for handling `None` inputs from concrete `MetricTasks` and removes the no longer necessary handling of `MetricComputationError`.