### PR TITLE
DM-35207: Reset MakeWarp visitSummary connection in ApTemplate.yaml

### DIFF
--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -21,6 +21,10 @@ tasks:
   makeWarp:
     class: lsst.pipe.tasks.makeCoaddTempExp.MakeWarpTask
     config:
+      # The upstream default is now finalVisitSummary, which doesn't exist
+      # in this pipeline since there's nothing to update relative to the
+      # original visitSummary.
+      connections.visitSummary: visitSummary
       doWriteEmptyWarps: True
       doApplyExternalPhotoCalib: False
       doApplyExternalSkyWcs: False

--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -19,7 +19,7 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
   makeWarp:
-    class: lsst.pipe.tasks.makeCoaddTempExp.MakeWarpTask
+    class: lsst.pipe.tasks.makeWarp.MakeWarpTask
     config:
       # The upstream default is now finalVisitSummary, which doesn't exist
       # in this pipeline since there's nothing to update relative to the


### PR DESCRIPTION
Running updateVisitSummary here (as is done in DRP) would be wasteful, as there are no updated calibration objects being produced in this pipeline.