### PR TITLE
DM-39467 Increase fake source density

### DIFF
--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -19,8 +19,20 @@ imports:
       - detectAndMeasure
       - diaPipe
       - transformDiaSrcCat
+parameters:
+  coaddName: goodSeeing
+  fakesType: 'fakes_'
 
 tasks:
+  createFakes:
+    class: lsst.ap.pipe.createApFakes.CreateRandomApFakesTask
+    config:
+      connections.fakesType: parameters.fakesType
+      magMin: 20
+      magMax: 27
+      fraction: 0
+      fakeDensity: 5000
+
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -24,9 +24,9 @@ tasks:
     config:
       connections.fakesType: parameters.fakesType
       magMin: 20
-      magMax: 26
+      magMax: 27
       fraction: 0
-      fakeDensity: 2000
+      fakeDensity: 5000
   coaddFakes:
     class: lsst.pipe.tasks.insertFakes.InsertFakesTask
     config:

--- a/python/lsst/ap/pipe/createApFakes.py
+++ b/python/lsst/ap/pipe/createApFakes.py
@@ -153,7 +153,8 @@ class CreateRandomApFakesTask(PipelineTask):
 
         self.log.info(
             f"Creating {nFakes} star fakes over tractId={tractId} with "
-            f"bounding circle area: {tractArea} deg^2")
+            f"bounding circle area: {tractArea:.4f} deg^2 and "
+            f"magnitude range: [{self.config.magMin, self.config.magMax}]")
 
         # Concatenate the data and add dummy values for the unused variables.
         # Set all data to PSF like objects.


### PR DESCRIPTION
This modifies the fake injection to increase the magnitude range and density of fakes. 
Setting new defaults for using fake-based metrics that require higher statistics. 

Probably density ends up being higher than needed. This would be a point of discussion before merging.