### PR TITLE
DM-39662 Add ApPipeWithFakes.yaml to LsstCamImSim

### DIFF
--- a/pipelines/LsstCamImSim/ApPipeWithFakes.yaml
+++ b/pipelines/LsstCamImSim/ApPipeWithFakes.yaml
@@ -1,0 +1,25 @@
+description: AP pipeline with synthetic/fakes sources specialized for ImSim
+# (1) Execute `make_apdb.py`, e.g.,
+#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
+#                  -c db_url="sqlite:////project/user/association.db"
+# (2) Run this pipeline, setting appropriate diaPipe configs
+#     (diaPipe configs should match the make_apdb.py configs)
+
+instrument: lsst.obs.lsst.LsstCamImSim
+imports:
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+    exclude:  # These tasks come from LsstCamImSim/ApPipe.yaml instead
+      - processCcd
+  - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipe.yaml
+    exclude:  # These tasks come from the ApPipeWithFakes.yaml
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - diaPipe
+      - transformDiaSrcCat
+
+tasks:
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE


### PR DESCRIPTION
Adding the yaml file for ImSim ApPipeWithFakes which was missing.

Requesting help to test with DC2 data at usdf.