### PR TITLE
DM-36477: Remove ap_verify_hits2015 dataset

### DIFF
--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -57,6 +57,7 @@ Databases can also be set up using :ref:`config files <command-line-task-config-
 
 .. code-block:: py
    :caption: myApdbConfig.py
+
    config.db_url = "sqlite:///databases/apdb.db"
 
 .. prompt:: bash

--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -53,7 +53,7 @@ In Gen 3, this becomes (see :ref:`ap-pipe-pipeline-tutorial` for an explanation 
    Note that the pipeline file given by ``-p`` may include APDB config overrides of its own.
    You can double-check what configuration is being run by calling :command:`pipetask run` with the ``--show config="apdb*"`` argument, though this lists *all* configuration options, including those left at their defaults.
 
-Databases can also be set up using :ref:`config files <command-line-task-config-howto-configfile>`:
+Databases can also be set up using :ref:`config files <command-line-config-howto-configfile>`:
 
 .. code-block:: py
    :caption: myApdbConfig.py

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -49,9 +49,7 @@ For the AP Pipeline to successfully process data, the following must be present 
 - **Calibration products** (biases, flats, and possibly others, depending on the instrument)
 
 - **Template images** for difference imaging.
-  These are of type ``deepCoadd`` by default, but the AP pipeline can be configured to use other types.
-
-.. TODO: update default for DM-14601
+  These are of type ``goodSeeingCoadd`` by default, but the AP pipeline can be configured to use other types (and :doc:`the Pipeline Tutorial <pipeline-tutorial>` does so).
 
 .. _ap_verify_hits2015: https://github.com/lsst/ap_verify_hits2015/
 

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -51,9 +51,9 @@ For the AP Pipeline to successfully process data, the following must be present 
 - **Template images** for difference imaging.
   These are of type ``goodSeeingCoadd`` by default, but the AP pipeline can be configured to use other types (and :doc:`the Pipeline Tutorial <pipeline-tutorial>` does so).
 
-.. _ap_verify_hits2015: https://github.com/lsst/ap_verify_hits2015/
+.. _ap_verify_ci_hits2015: https://github.com/lsst/ap_verify_ci_hits2015/
 
-A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ that works with ``ap_pipe`` in the :doc:`ap_verify format</modules/lsst.ap.verify/datasets>` is available as `ap_verify_hits2015`_.
+A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ that works with ``ap_pipe`` in the :doc:`ap_verify format</modules/lsst.ap.verify/datasets>` is available as `ap_verify_ci_hits2015`_.
 However, raw images from this dataset must be ingested.
 
 Please continue to :doc:`the Pipeline Tutorial <pipeline-tutorial>` for more details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -53,7 +53,7 @@ For the AP Pipeline to successfully process data, the following must be present 
 
 .. _ap_verify_hits2015: https://github.com/lsst/ap_verify_hits2015/
 
-A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ that works with ``ap_pipe`` in the :doc:`/modules/lsst.ap.verify/datasets` format is available as `ap_verify_hits2015`_.
+A sample dataset from the `DECam HiTS survey <http://iopscience.iop.org/article/10.3847/0004-637X/832/2/155/meta>`_ that works with ``ap_pipe`` in the :doc:`ap_verify format</modules/lsst.ap.verify/datasets>` is available as `ap_verify_hits2015`_.
 However, raw images from this dataset must be ingested.
 
 Please continue to :doc:`the Pipeline Tutorial <pipeline-tutorial>` for more details about running the AP Pipeline and interpreting the results.

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -31,15 +31,15 @@ AP pipeline on the command line
 Like most Vera Rubin Observatory pipelines, the AP Pipeline is run with an external runner called ``pipetask``.
 This can be found in the ``ctrl_mpexec`` package, which is included as part of ``lsst_distrib``.
 
-The pipeline itself is configured in `ap_pipe/pipelines/ApPipe.yaml <https://github.com/lsst/ap_pipe/blob/master/pipelines/ApPipe.yaml>`_.
+The pipeline itself is configured in `ap_pipe/pipelines/DECam/ApPipe.yaml <https://github.com/lsst/ap_pipe/blob/master/pipelines/DECam/ApPipe.yaml>`_.
 
 To process your ingested data, run
 
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c db_url="sqlite:///apdb/association.db"
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" -o processed -d "visit in (123456, 123457) and detector=42"
+   make_apdb.py -c db_url="sqlite:///apdb.db"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml --register-dataset-types -c parameters:coaddName=deep -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "DECam/defaults,DECam/raw/all" -o processed -d "visit in (123456, 123457) and detector=42"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
@@ -51,12 +51,12 @@ If you prefer to have a standalone output collection, you may instead run
 
 .. prompt:: bash
 
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/ApPipe.yaml --instrument lsst.obs.decam.DarkEnergyCamera --register-dataset-types -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "templates/deep,skymaps,DECam/raw/all,DECam/calib,refcats" --output-run processed -d "visit in (123456, 123457) and detector=42"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml --register-dataset-types -c parameters:coaddName=deep -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "DECam/defaults,DECam/raw/all" --output-run processed -d "visit in (123456, 123457) and detector=42"
 
 .. note::
 
-   If you are using the default (SQLite) association database, you must :doc:`configure </modules/lsst.pipe.base/command-line-task-config-howto>` the database location, or ``ap_pipe`` will not run.
-   The location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
+   You must :doc:`configure </modules/lsst.pipe.base/command-line-task-config-howto>` the database location, or ``ap_pipe`` will not run.
+   For the default (SQLite) association database, the location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
    In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
 
 .. note::
@@ -76,8 +76,7 @@ The result from running ``ap_pipe`` should look something like
 
 .. code-block:: none
 
-   apdb/
-      association.db   <--- the Alert Production Database with DIAObjects
+   apdb.db   <--- the Alert Production Database with DIAObjects
    repo/
       contains_no_user_servicable_files/
 
@@ -103,8 +102,9 @@ Supplemental information
 Running on other cameras
 ------------------------
 
-Running ap_pipe on cameras other than DECam works much the same way:.
+Running ap_pipe on cameras other than DECam works much the same way.
 You need to provide a repository containing raws, calibs, and templates appropriate for the camera.
+There are versions of the AP pipeline for DECam, HSC, LATISS, and ImSim.
 
 Common errors
 -------------

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -44,12 +44,12 @@ To process your ingested data, run
        -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
        -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
        -i "DECam/defaults,DECam/raw/all" -o processed \
-       -d "visit in (123456, 123457) and detector=42"
+       -d "visit in (411420, 419802) and detector=10"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
 
-This example command only processes observations corresponding to visits 123456 and 123457, both with only detector 42.
+This example command only processes observations corresponding to visits 411420 and 419802, both with only detector 10.
 
 The example creates a "chained" output collection that can refer back to its inputs.
 If you prefer to have a standalone output collection, you may instead run
@@ -61,7 +61,7 @@ If you prefer to have a standalone output collection, you may instead run
        -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
        -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
        -i "DECam/defaults,DECam/raw/all" --output-run processed \
-       -d "visit in (123456, 123457) and detector=42"
+       -d "visit in (411420, 419802) and detector=10"
 
 .. note::
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -65,7 +65,7 @@ If you prefer to have a standalone output collection, you may instead run
 
 .. note::
 
-   You must :doc:`configure </modules/lsst.pipe.base/command-line-task-config-howto>` the database location, or ``ap_pipe`` will not run.
+   You must :doc:`configure </modules/lsst.ctrl.mpexec/configuring-pipetask-tasks>` the database location, or ``ap_pipe`` will not run.
    For the default (SQLite) association database, the location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
    In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -39,7 +39,12 @@ To process your ingested data, run
 
    mkdir apdb/
    make_apdb.py -c db_url="sqlite:///apdb.db"
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml --register-dataset-types -c parameters:coaddName=deep -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "DECam/defaults,DECam/raw/all" -o processed -d "visit in (123456, 123457) and detector=42"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml \
+       --register-dataset-types -c parameters:coaddName=deep \
+       -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
+       -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
+       -i "DECam/defaults,DECam/raw/all" -o processed \
+       -d "visit in (123456, 123457) and detector=42"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
 See :doc:`apdb` for more information on :command:`make_apdb.py`.
@@ -51,7 +56,12 @@ If you prefer to have a standalone output collection, you may instead run
 
 .. prompt:: bash
 
-   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml --register-dataset-types -c parameters:coaddName=deep -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ -i "DECam/defaults,DECam/raw/all" --output-run processed -d "visit in (123456, 123457) and detector=42"
+   pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml \
+       --register-dataset-types -c parameters:coaddName=deep \
+       -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
+       -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
+       -i "DECam/defaults,DECam/raw/all" --output-run processed \
+       -d "visit in (123456, 123457) and detector=42"
 
 .. note::
 


### PR DESCRIPTION
This PR fixes a large number of build problems and outdated information in the `ap_pipe` documentation, then updates the tutorial to use `ap_verify_ci_hits2015` instead of the obsolete `ap_verify_hits2015`.