### PR TITLE
DM-40210: Clean up ap_pipe and ap_verify pipelines

### DIFF
--- a/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml
@@ -3,8 +3,7 @@ description: DECam AP Pipeline with synthetic/fake sources. Templates are inputs
 # (0) Ensure median calibration products and template coadds exist for the data being processed
 # (1) Run $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
 # (2) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
 # (3) Run this pipeline, setting appropriate diaPipe configs
 #     (diaPipe configs must match the make_apdb.py configs)
 

--- a/pipelines/DarkEnergyCamera/ProcessCcd.yaml
+++ b/pipelines/DarkEnergyCamera/ProcessCcd.yaml
@@ -24,8 +24,6 @@ tasks:
       file: $AP_PIPE_DIR/config/DECam/calibrate.py
       # Do not integrate file and pipeline configs until DM-31047 fixed, to
       # make it easier to check for changes on the obs side.
-      photoCal.match.referenceSelection.magLimit.fluxField: 'i_flux'
-      photoCal.match.referenceSelection.magLimit.maximum: 22.0
 subsets:
 # processCcd must be redefined from
 # $AP_PIPE_DIR/pipelines/_ingredients/ProcessCcd.yaml because its isr was

--- a/pipelines/DarkEnergyCamera/ProcessCcd.yaml
+++ b/pipelines/DarkEnergyCamera/ProcessCcd.yaml
@@ -11,15 +11,19 @@ tasks:
   characterizeImage:
     class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/DECam/characterizeImage.py
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/DECam/calibrate.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       photoCal.match.referenceSelection.magLimit.fluxField: 'i_flux'
       photoCal.match.referenceSelection.magLimit.maximum: 22.0
 subsets:

--- a/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
@@ -4,7 +4,6 @@ tasks:
   overscan:
     class: lsst.ip.isr.IsrTask
     config:
-      connections.ccdExposure: 'raw'
       connections.outputExposure: 'overscanRaw'
       doBias: False
       doOverscan: True

--- a/pipelines/DarkEnergyCamera/RunIsrWithCrosstalk.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrWithCrosstalk.yaml
@@ -4,9 +4,6 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTask
     config:
-      connections.ccdExposure: 'raw'
       connections.crosstalkSources: 'overscanRaw'
-      connections.bias: 'bias'  # DECam default is still 'cpBias'
-      connections.flat: 'flat'  # DECam default is still 'cpFlat'
       doOverscan: True
       doCrosstalk: True

--- a/pipelines/DarkEnergyCamera/RunIsrWithoutInterChipCrosstalk.yaml
+++ b/pipelines/DarkEnergyCamera/RunIsrWithoutInterChipCrosstalk.yaml
@@ -4,6 +4,5 @@ tasks:
   isr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
-      connections.ccdExposure: 'raw'
       doLinearize: False
       doCrosstalk: True

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -36,9 +36,11 @@ tasks:
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/HSC/processCcdWithFakes.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       connections.coaddName: parameters.coaddName

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -44,6 +44,7 @@ tasks:
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: 'isVisitSource'
       calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -2,8 +2,7 @@ description: HSC AP Pipeline with synthetic/fake sources. Templates are inputs.
 # Remember:
 # (0) Ensure median calibration products and template coadds exist for the data being processed
 # (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
 # (2) Run this pipeline, setting appropriate diaPipe configs
 #     (diaPipe configs must match the make_apdb.py configs)
 

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -34,8 +34,6 @@ tasks:
       connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: 'isVisitSource'
-      calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
-      calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml
@@ -12,26 +12,14 @@ imports:
     exclude:  # These tasks frome from HSC's ApPipe.yaml instead
       - processCcd
   - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml
-    exclude:  # These tasks come from ApPipeWithFakes.yaml instead
+    exclude:  # These tasks come from _ingredients/ApPipeWithFakes.yaml instead
       - retrieveTemplate
       - subtractImages
       - detectAndMeasure
       - diaPipe
       - transformDiaSrcCat
-parameters:
-  coaddName: goodSeeing
-  fakesType: 'fakes_'
 
 tasks:
-  createFakes:
-    class: lsst.ap.pipe.createApFakes.CreateRandomApFakesTask
-    config:
-      connections.fakesType: parameters.fakesType
-      magMin: 20
-      magMax: 27
-      fraction: 0
-      fakeDensity: 5000
-
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:

--- a/pipelines/HyperSuprimeCam/ApTemplate.yaml
+++ b/pipelines/HyperSuprimeCam/ApTemplate.yaml
@@ -14,9 +14,11 @@ tasks:
   makeWarp:
     class: lsst.pipe.tasks.makeWarp.MakeWarpTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/HSC/makeWarp.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       connections.visitSummary: "{calexpType}visitSummary"
@@ -26,9 +28,11 @@ tasks:
   assembleCoadd:
     class: lsst.pipe.tasks.assembleCoadd.CompareWarpAssembleCoaddTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/HSC/assembleCoadd.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       doSelectVisits: True

--- a/pipelines/HyperSuprimeCam/ProcessCcd.yaml
+++ b/pipelines/HyperSuprimeCam/ProcessCcd.yaml
@@ -7,14 +7,18 @@ tasks:
   characterizeImage:
     class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/HSC/characterizeImage.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/HSC/calibrate.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.

--- a/pipelines/LsstCamImSim/ApPipe.yaml
+++ b/pipelines/LsstCamImSim/ApPipe.yaml
@@ -1,7 +1,6 @@
 description: End to end AP pipeline specialized for ImSim
 # (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
 # (2) Run this pipeline, setting appropriate diaPipe configs
 #     (diaPipe configs should match the make_apdb.py configs)
 

--- a/pipelines/LsstCamImSim/ApTemplate.yaml
+++ b/pipelines/LsstCamImSim/ApTemplate.yaml
@@ -12,9 +12,11 @@ tasks:
   makeWarp:
     class: lsst.pipe.tasks.makeWarp.MakeWarpTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/makeWarp.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       connections.visitSummary: "{calexpType}visitSummary"
@@ -24,9 +26,11 @@ tasks:
   assembleCoadd:
     class: lsst.pipe.tasks.assembleCoadd.CompareWarpAssembleCoaddTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/assembleCoadd.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
       doSelectVisits: True

--- a/pipelines/LsstCamImSim/ProcessCcd.yaml
+++ b/pipelines/LsstCamImSim/ProcessCcd.yaml
@@ -13,17 +13,21 @@ tasks:
   characterizeImage:
     class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/characterizeImage.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       # Config file wipes out all pre-existing configs, so copy base pipeline
       # config on top.
   calibrate:
     class: lsst.pipe.tasks.calibrate.CalibrateTask
     config:
+      # HACK: workaround for DM-31047, remove once we're no longer loading
+      # DRP-specific obs configs.
       file: $AP_PIPE_DIR/config/LSSTCam-imSim/calibrate.py
-      # Do not integrate file and pipeline configs until obs config files are
-      # gone, to make it easier to check for changes on the obs side.
+      # Do not integrate file and pipeline configs until DM-31047 fixed, to
+      # make it easier to check for changes on the obs side.
       connections.astromRefCat: 'cal_ref_cat_2_2'
       connections.photoRefCat: 'cal_ref_cat_2_2'
       python: >

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -41,8 +41,6 @@ tasks:
       connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: 'isVisitSource'
-      calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
-      calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
   retrieveTemplateWithFakes:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:


### PR DESCRIPTION
This PR removes a large amount of duplicate pipeline configuration, particularly base (`_ingredients`) configs and tasks copied to instrument-specific pipelines. This leaves the pipelines cleaner and with clearer responsibilities, and will prevent changes to the base pipeline from unexpectedly not working.

Unfortunately, not all of the duplicate configs in the instrument pipelines could be removed, as some are still needed as workarounds for DRP-specific settings/plugins lurking in the `obs` package configs.