### PR TITLE
DM-42489: Update factory method for changes in Apdb.makeSchema interface

### DIFF
--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -116,8 +116,8 @@ def makeApdb(args=None):
     parser = ConfigOnlyParser()
     parsedCmd = parser.parse_args(args=args)
 
+    daxApdb.Apdb.makeSchema(parsedCmd.config)
     apdb = daxApdb.make_apdb(config=parsedCmd.config)
-    apdb.makeSchema()
     return apdb
 
 


### PR DESCRIPTION


The `makeSchema` method is now a class method instead of instance method and it takes configuration object as a parameter.