### PR TITLE
DM-42762: Make ApPipe contracts more human-friendly

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -72,7 +72,8 @@ subsets:
       An alias of ApPipe to use in higher-level pipelines.
 contracts:
   - detectAndMeasure.doSkySources == transformDiaSrcCat.doRemoveSkySources
-  # Inputs and outputs must match
+  # Inputs and outputs must match. For consistency, contracts are written in execution order:
+  #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
       subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
@@ -84,18 +85,18 @@ contracts:
       diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
   - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
       filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+      rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
   - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
       transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
   - (not transformDiaSrcCat.doIncludeReliability) or
         (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
             transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -75,30 +75,43 @@ contracts:
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
-      subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
-      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-      filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
-  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-  - (not transformDiaSrcCat.doIncludeReliability) or
-        (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
-            transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
-  - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
+  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
+    msg: "retrieveTemplate.template != subtractImages.template"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
+              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
+    msg: "subtractImages.difference != detectAndMeasure.difference"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
+              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
+    msg: "subtractImages.science != detectAndMeasure.science"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
+    msg: "subtractImages.template != diaPipe.template"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+    msg: "subtractImages.science != diaPipe.exposure"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+              filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
+    msg: "detectAndMeasure.diaSources != filterDiaSrcCat.diaSourceCat"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != rbClassify.difference"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != transformDiaSrcCat.diffIm"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != diaPipe.diffIm"
+  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+              rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
+    msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
+  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
+    msg: "filterDiaSrcCat.filteredDiaSourceCat != transformDiaSrcCat.diaSourceCat"
+  - contract: (not transformDiaSrcCat.doIncludeReliability) or
+              (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
+               transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
+    msg: "rbClassify.classifications != transformDiaSrcCat.reliability"
+  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
+    msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"

--- a/pipelines/_ingredients/ApPipeCalibrateImage.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrateImage.yaml
@@ -82,36 +82,52 @@ contracts:
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - calibrateImage.connections.ConnectionsClass(config=calibrateImage).output_exposure.name ==
-      subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
-  - calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars.name ==
-      subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
-  - calibrateImage.connections.ConnectionsClass(config=calibrateImage).output_exposure.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).science.name
-  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
-      subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
-      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-      filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
-  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-  - (not transformDiaSrcCat.doIncludeReliability) or
-        (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
-            transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
-  - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).output_exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.output_exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).output_exposure.name ==
+              rbClassify.connections.ConnectionsClass(config=rbClassify).science.name
+    msg: "calibrateImage.output_exposure != rbClassify.science"
+  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
+    msg: "retrieveTemplate.template != subtractImages.template"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
+              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
+    msg: "subtractImages.difference != detectAndMeasure.difference"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
+              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
+    msg: "subtractImages.science != detectAndMeasure.science"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
+    msg: "subtractImages.template != diaPipe.template"
+  - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+    msg: "subtractImages.science != diaPipe.exposure"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+              filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
+    msg: "detectAndMeasure.diaSources != filterDiaSrcCat.diaSourceCat"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != rbClassify.difference"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != transformDiaSrcCat.diffIm"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+    msg: "detectAndMeasure.subtractedMeasuredExposure != diaPipe.diffIm"
+  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+              rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
+    msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
+  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
+    msg: "filterDiaSrcCat.filteredDiaSourceCat != transformDiaSrcCat.diaSourceCat"
+  - contract: (not transformDiaSrcCat.doIncludeReliability) or
+              (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
+               transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
+    msg: "rbClassify.classifications != transformDiaSrcCat.reliability"
+  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
+    msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"

--- a/pipelines/_ingredients/ApPipeCalibrateImage.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrateImage.yaml
@@ -73,7 +73,8 @@ subsets:
       An alias of ApPipe to use in higher-level pipelines.
 contracts:
   - detectAndMeasure.doSkySources == transformDiaSrcCat.doRemoveSkySources
-  # Inputs and outputs must match
+  # Inputs and outputs must match. For consistency, contracts are written in execution order:
+  #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - calibrateImage.connections.ConnectionsClass(config=calibrateImage).output_exposure.name ==
       subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
@@ -94,7 +95,7 @@ contracts:
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-        rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
+      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==

--- a/pipelines/_ingredients/ApPipeCalibrateImage.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrateImage.yaml
@@ -41,6 +41,11 @@ tasks:
       connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
       doSkySources: True
+  filterDiaSrcCat:
+    class: lsst.ap.association.FilterDiaSourceCatalogTask
+    config:
+      doRemoveSkySources: True
+      connections.coaddName: parameters.coaddName
   rbClassify:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
@@ -66,6 +71,7 @@ subsets:
       - retrieveTemplate
       - subtractImages
       - detectAndMeasure
+      - filterDiaSrcCat
       - rbClassify
       - transformDiaSrcCat
       - diaPipe
@@ -92,16 +98,18 @@ contracts:
       diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
   - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+      filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
         diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+      rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
+  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
   - (not transformDiaSrcCat.doIncludeReliability) or
         (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
             transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -57,6 +57,12 @@ tasks:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       doSkySources: True
+  filterDiaSrcCatWithFakes:
+    class: lsst.ap.association.FilterDiaSourceCatalogTask
+    config:
+      doRemoveSkySources: True
+      connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
   rbClassifyWithFakes:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
@@ -97,6 +103,7 @@ subsets:
       - retrieveTemplateWithFakes
       - subtractImagesWithFakes
       - detectAndMeasureWithFakes
+      - filterDiaSrcCatWithFakes
       - rbClassifyWithFakes
       - transformDiaSrcCatWithFakes
       - diaPipe
@@ -129,18 +136,20 @@ contracts:
       diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
   - subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).diaSources.name ==
+      filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).diaSourceCat.name
   - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
       rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).difference.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).diaSources.name ==
-      rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).diaSources.name
   - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
       transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diffIm.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).diaSources.name ==
-      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceCat.name
   - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
   - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
       fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
+  - filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
+      rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).diaSources.name
+  - filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
+      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceCat.name
   - (not transformDiaSrcCatWithFakes.doIncludeReliability) or
         (rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).classifications.name ==
             transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).reliability.name)

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -116,44 +116,64 @@ contracts:
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
-  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
-      subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name
-  - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
-      retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
-  - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).template.name ==
-      subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).template.name
-  - subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).difference.name ==
-      detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).difference.name
-  - subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name ==
-      detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).science.name
-  - subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).template.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-  - subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).diaSources.name ==
-      filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).diaSourceCat.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
-      rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).difference.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
-      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diffIm.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-  - detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
-  - filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
-      rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).diaSources.name
-  - filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
-      transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceCat.name
-  - (not transformDiaSrcCatWithFakes.doIncludeReliability) or
-        (rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).classifications.name ==
-            transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).reliability.name)
-  - transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceTable.name ==
-      diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
-  - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
+  - contract: createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+              coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
+    msg: "createFakes.fakeCat != coaddFakes.fakeCat"
+  - contract: createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+              processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
+    msg: "createFakes.fakeCat != processVisitFakes.fakeCats"
+  - contract: createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+              fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
+    msg: "createFakes.fakeCat != fakesMatch.fakeCats"
+  - contract: processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
+              subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name
+    msg: "processVisitFakes.outputExposure != subtractImagesWithFakes.science"
+  - contract: coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
+              retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
+    msg: "coaddFakes.imageWithFakes != retrieveTemplateWithFakes.coaddExposures"
+  - contract: retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).template.name ==
+              subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).template.name
+    msg: "retrieveTemplateWithFakes.template != subtractImagesWithFakes.template"
+  - contract: subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).difference.name ==
+              detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).difference.name
+    msg: "subtractImagesWithFakes.difference != detectAndMeasureWithFakes.difference"
+  - contract: subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name ==
+              detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).science.name
+    msg: "subtractImagesWithFakes.science != detectAndMeasureWithFakes.science"
+  - contract: subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).template.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
+    msg: "subtractImagesWithFakes.template != diaPipe.template"
+  - contract: subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+    msg: "subtractImagesWithFakes.science != diaPipe.exposure"
+  - contract: detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).diaSources.name ==
+              filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).diaSourceCat.name
+    msg: "detectAndMeasureWithFakes.diaSources != filterDiaSrcCatWithFakes.diaSourceCat"
+  - contract: detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
+              rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).difference.name
+    msg: "detectAndMeasureWithFakes.subtractedMeasuredExposure != rbClassifyWithFakes.difference"
+  - contract: detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
+              transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diffIm.name
+    msg: "detectAndMeasureWithFakes.subtractedMeasuredExposure != transformDiaSrcCatWithFakes.diffIm"
+  - contract: detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
+    msg: "detectAndMeasureWithFakes.subtractedMeasuredExposure != diaPipe.diffIm"
+  - contract: detectAndMeasureWithFakes.connections.ConnectionsClass(config=detectAndMeasureWithFakes).subtractedMeasuredExposure.name ==
+              fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
+    msg: "detectAndMeasureWithFakes.subtractedMeasuredExposure != fakesMatch.diffIm"
+  - contract: filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
+              rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).diaSources.name
+    msg: "filterDiaSrcCatWithFakes.filteredDiaSourceCat != rbClassifyWithFakes.diaSources"
+  - contract: filterDiaSrcCatWithFakes.connections.ConnectionsClass(config=filterDiaSrcCatWithFakes).filteredDiaSourceCat.name ==
+              transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceCat.name
+    msg: "filterDiaSrcCatWithFakes.filteredDiaSourceCat != transformDiaSrcCatWithFakes.diaSourceCat"
+  - contract: (not transformDiaSrcCatWithFakes.doIncludeReliability) or
+              (rbClassifyWithFakes.connections.ConnectionsClass(config=rbClassifyWithFakes).classifications.name ==
+               transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).reliability.name)
+    msg: "rbClassifyWithFakes.classifications != transformDiaSrcCatWithFakes.reliability"
+  - contract: transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceTable.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
+    msg: "transformDiaSrcCatWithFakes.diaSourceTable != diaPipe.diaSourceTable"
+  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
+              fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
+    msg: "diaPipe.associatedDiaSources != fakesMatch.associatedDiaSources"

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -106,12 +106,17 @@ subsets:
 
 contracts:
   - detectAndMeasureWithFakes.doSkySources == transformDiaSrcCatWithFakes.doRemoveSkySources
-  # Inputs and outputs must match.
+  # Inputs and outputs must match. For consistency, contracts are written in execution order:
+  #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
+  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
+      subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name
   - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
       retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
   - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).template.name ==
@@ -141,9 +146,5 @@ contracts:
             transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).reliability.name)
   - transformDiaSrcCatWithFakes.connections.ConnectionsClass(config=transformDiaSrcCatWithFakes).diaSourceTable.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
-  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
-      subtractImagesWithFakes.connections.ConnectionsClass(config=subtractImagesWithFakes).science.name
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
   - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
       fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name

--- a/pipelines/_ingredients/ApTemplate.yaml
+++ b/pipelines/_ingredients/ApTemplate.yaml
@@ -70,15 +70,21 @@ contracts:
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - calibrate.connections.outputExposure ==
-      consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).calexp.name
-  - calibrate.connections.outputExposure ==
-      makeWarp.connections.ConnectionsClass(config=makeWarp).calExpList.name
-  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
-      selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).visitSummaries.name
-  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
-      makeWarp.connections.ConnectionsClass(config=makeWarp).visitSummary.name
-  - selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).goodVisits.name ==
-      assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).selectedVisits.name
-  - makeWarp.connections.ConnectionsClass(config=makeWarp).psfMatched.name ==
-      assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).psfMatchedWarps.name
+  - contract: calibrate.connections.outputExposure ==
+              consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).calexp.name
+    msg: "calibrate.outputExposure != consolidateVisitSummary.calexp"
+  - contract: calibrate.connections.outputExposure ==
+              makeWarp.connections.ConnectionsClass(config=makeWarp).calExpList.name
+    msg: "calibrate.outputExposure != makeWarp.calExpList"
+  - contract: consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
+              selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).visitSummaries.name
+    msg: "consolidateVisitSummary.visitSummary != selectGoodSeeingVisits.visitSummaries"
+  - contract: consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
+              makeWarp.connections.ConnectionsClass(config=makeWarp).visitSummary.name
+    msg: "consolidateVisitSummary.visitSummary != makeWarp.visitSummary"
+  - contract: selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).goodVisits.name ==
+              assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).selectedVisits.name
+    msg: "selectGoodSeeingVisits.goodVisits != assembleCoadd.selectedVisits"
+  - contract: makeWarp.connections.ConnectionsClass(config=makeWarp).psfMatched.name ==
+              assembleCoadd.connections.ConnectionsClass(config=assembleCoadd).psfMatchedWarps.name
+    msg: "makeWarp.psfMatched != assembleCoadd.psfMatchedWarps"

--- a/pipelines/_ingredients/ApTemplate.yaml
+++ b/pipelines/_ingredients/ApTemplate.yaml
@@ -67,13 +67,15 @@ subsets:
 contracts:
   - makeWarp.makeDirect is True
   - makeWarp.makePsfMatched is True
+  # Inputs and outputs must match. For consistency, contracts are written in execution order:
+  #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - calibrate.connections.outputExposure ==
       consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).calexp.name
-  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
-      selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).visitSummaries.name
   - calibrate.connections.outputExposure ==
       makeWarp.connections.ConnectionsClass(config=makeWarp).calExpList.name
+  - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
+      selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).visitSummaries.name
   - consolidateVisitSummary.connections.ConnectionsClass(config=consolidateVisitSummary).visitSummary.name ==
       makeWarp.connections.ConnectionsClass(config=makeWarp).visitSummary.name
   - selectGoodSeeingVisits.connections.ConnectionsClass(config=selectGoodSeeingVisits).goodVisits.name ==


### PR DESCRIPTION
This PR fixes missing `filterDiaSrcCat` in the secondary pipelines (a pipeline-breaking bug since the default connections for `rbClassify` and `transformDiaSrcCat` assume it), and then adds a `msg` argument to each connection contract.