### PR TITLE
DM-42220: Incorporate ModelPackage Butler datasets into Prompt Processing

### DIFF
--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -5,13 +5,3 @@ description: |
 instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
-    exclude:
-      # TODO: prompt_prototype does not yet support R/B analysis: DM-42220.
-      - rbClassify
-
-tasks:
-  transformDiaSrcCat:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      # TODO: prompt_prototype does not yet support R/B analysis: DM-42220.
-      doIncludeReliability: False


### PR DESCRIPTION
This PR removes the pre-emptive blocker that prevented `rbClassify` from being run in LATISS (specifically, Prompt Processing). It must be merged after lsst-dm/prompt_processing#125.