### PR TITLE
DM-43037: ap_pipe BPS scripts use old task names

### DIFF
--- a/bps/clustering/clustering_ApPipe.yaml
+++ b/bps/clustering/clustering_ApPipe.yaml
@@ -24,6 +24,6 @@ cluster:
     dimensions: visit,detector
     equalDimensions: visit:exposure
   diffim:
-    pipetasks: retrieveTemplate,subtractImages,detectAndMeasure,transformDiaSrcCat,diaPipe
+    pipetasks: retrieveTemplate,subtractImages,detectAndMeasure,filterDiaSrcCat,rbClassify,transformDiaSrcCat,diaPipe
     dimensions: visit,detector
     equalDimensions: visit:exposure

--- a/bps/clustering/clustering_ApPipeWithFakes.yaml
+++ b/bps/clustering/clustering_ApPipeWithFakes.yaml
@@ -26,6 +26,6 @@ cluster:
     pipetasks: coaddFakes
     dimensions: tract,patch
   diffim:
-    pipetasks: processVisitFakes,retrieveTemplateWithFakes,subtractImagesWithFakes,detectAndMeasureWithFakes,transformDiaSrcCatWithFakes,diaPipe,fakesMatch
+    pipetasks: processVisitFakes,retrieveTemplate,subtractImages,detectAndMeasure,transformDiaSrcCat,diaPipe,fakesMatch
     dimensions: visit,detector
     equalDimensions: visit:exposure

--- a/bps/clustering/clustering_ApPipeWithFakes.yaml
+++ b/bps/clustering/clustering_ApPipeWithFakes.yaml
@@ -19,6 +19,7 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   singleFrame:
+    # TODO DM-40388: replace this with isr,calibrateImage
     pipetasks: isr,characterizeImage,calibrate
     dimensions: visit,detector
     equalDimensions: visit:exposure
@@ -26,6 +27,6 @@ cluster:
     pipetasks: coaddFakes
     dimensions: tract,patch
   diffim:
-    pipetasks: processVisitFakes,retrieveTemplate,subtractImages,detectAndMeasure,transformDiaSrcCat,diaPipe,fakesMatch
+    pipetasks: processVisitFakes,retrieveTemplate,subtractImages,detectAndMeasure,filterDiaSrcCat,rbClassify,transformDiaSrcCat,diaPipe,fakesMatch
     dimensions: visit,detector
     equalDimensions: visit:exposure


### PR DESCRIPTION
This PR updates the BPS clustering files to use the same task labels as their corresponding pipeline (with one exception; `clustering_ApPipeWithFakes.yaml` does not include `createFakes`). These changes are updates in response to #156, #157, and #163.