### PR TITLE
DM-40400: Create total AP pipeline timing metric

### DIFF
--- a/python/lsst/ap/pipe/metrics.py
+++ b/python/lsst/ap/pipe/metrics.py
@@ -25,18 +25,20 @@
 
 __all__ = [
     "ApFakesCompletenessMetricTask", "ApFakesCompletenessMetricConfig",
-    "ApFakesCountMetricTask", "ApFakesCountMetricConfig"
+    "ApFakesCountMetricTask", "ApFakesCountMetricConfig",
+    "PipelineTimingMetricTask", "PipelineTimingMetricConfig",
 ]
 
 import astropy.units as u
+from datetime import datetime
 import numpy as np
 
 import lsst.pex.config as pexConfig
-from lsst.pipe.base import Struct
+from lsst.pipe.base import Struct, NoWorkFound
 import lsst.pipe.base.connectionTypes as connTypes
 from lsst.pipe.tasks.insertFakes import InsertFakesConfig
-from lsst.verify import Measurement
-from lsst.verify.tasks import MetricTask, MetricComputationError
+from lsst.verify import Measurement, Datum
+from lsst.verify.tasks import AbstractMetadataMetricTask, MetricTask, MetricComputationError
 
 
 class ApFakesCompletenessMetricConnections(
@@ -187,3 +189,133 @@ class ApFakesCountMetricTask(ApFakesCompletenessMetricTask):
         meas = Measurement(self.config.metricName,
                            len(magCutFakes) * u.count)
         return Struct(measurement=meas)
+
+
+class PipelineTimingMetricConnections(
+        MetricTask.ConfigClass.ConnectionsClass,
+        dimensions={"instrument", "visit", "detector"},
+        defaultTemplates={"labelStart": "",
+                          "labelEnd": "",
+                          "package": "ap_pipe",
+                          "metric": "ApPipelineTime"}):
+    metadataStart = connTypes.Input(
+        name="{labelStart}_metadata",
+        doc="The starting task's metadata.",
+        storageClass="TaskMetadata",
+        dimensions={"instrument", "exposure", "detector"},
+        multiple=False,
+    )
+    metadataEnd = connTypes.Input(
+        name="{labelEnd}_metadata",
+        doc="The final task's metadata.",
+        storageClass="TaskMetadata",
+        dimensions={"instrument", "visit", "detector"},
+        multiple=False,
+    )
+
+
+class PipelineTimingMetricConfig(MetricTask.ConfigClass, pipelineConnections=PipelineTimingMetricConnections):
+    # Don't include the dimensions hack that MetadataMetricConfig has; unlike
+    # TimingMetricTask, this task is not designed to be run on multiple
+    # pipelines.
+    targetStart = pexConfig.Field(
+        dtype=str,
+        doc="The method to take as the starting point of the starting task, "
+            "optionally prefixed by one or more task names in the format of "
+            "`lsst.pipe.base.Task.getFullMetadata()`.")
+    targetEnd = pexConfig.Field(
+        dtype=str,
+        doc="The method to take as the stopping point of the final task, "
+            "optionally prefixed by one or more task names in the format of "
+            "`lsst.pipe.base.Task.getFullMetadata()`.")
+
+
+class PipelineTimingMetricTask(AbstractMetadataMetricTask):
+    """A Task that computes a wall-clock time for an entire pipeline, using
+    metadata produced by the `lsst.utils.timer.timeMethod` decorator.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.verify.tasks.MetricTask`.
+    """
+
+    _DefaultName = "pipelineTimingMetric"
+    ConfigClass = PipelineTimingMetricConfig
+
+    @classmethod
+    def getInputMetadataKeys(cls, config):
+        """Get search strings for the metadata.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keys : `dict`
+            A dictionary of keys, optionally prefixed by one or more tasks in
+            the format of `lsst.pipe.base.Task.getFullMetadata()`.
+
+             ``"StartTimestamp"``
+                 The key for an ISO 8601-compliant text string where the target
+                 pipeline started (`str`).
+             ``"EndTimestamp"``
+                 The key for an ISO 8601-compliant text string where the target
+                 pipeline ended (`str`).
+        """
+        return {"StartTimestamp": config.targetStart + "StartUtc",
+                "EndTimestamp": config.targetEnd + "EndUtc",
+                }
+
+    def run(self, metadataStart, metadataEnd):
+        """Compute the pipeline wall-clock time from science task metadata.
+
+        Parameters
+        ----------
+        metadataStart : `lsst.pipe.base.TaskMetadata`
+            A metadata object for the first quantum run by the pipeline.
+        metadataEnd : `lsst.pipe.base.TaskMetadata`
+            A metadata object for the last quantum run by the pipeline.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            - ``measurement``: the value of the metric
+              (`lsst.verify.Measurement` or `None`)
+
+        Raises
+        ------
+        lsst.verify.tasks.MetricComputationError
+            Raised if the strings returned by `getInputMetadataKeys` match
+            more than one key in either metadata object.
+        lsst.pipe.base.NoWorkFound
+            Raised if the metric is ill-defined. Typically this means that at
+            least one pipeline step was not run.
+        """
+        metadataKeys = self.getInputMetadataKeys(self.config)
+        timingsStart = self.extractMetadata(metadataStart, metadataKeys)
+        timingsEnd = self.extractMetadata(metadataEnd, metadataKeys)
+
+        if timingsStart["StartTimestamp"] is None:
+            raise NoWorkFound(f"Nothing to do: no timing information for {self.config.targetStart} found.")
+        if timingsEnd["EndTimestamp"] is None:
+            raise NoWorkFound(f"Nothing to do: no timing information for {self.config.targetEnd} found.")
+
+        try:
+            startTime = datetime.fromisoformat(timingsStart["StartTimestamp"])
+            endTime = datetime.fromisoformat(timingsEnd["EndTimestamp"])
+        except (TypeError, ValueError) as e:
+            raise MetricComputationError("Invalid metadata") from e
+        else:
+            totalTime = (endTime - startTime).total_seconds()
+            meas = Measurement(self.config.metricName, totalTime * u.second)
+            meas.notes["estimator"] = "utils.timer.timeMethod"
+            meas.extras["start"] = Datum(timingsStart["StartTimestamp"])
+            meas.extras["end"] = Datum(timingsEnd["EndTimestamp"])
+            return Struct(measurement=meas)


### PR DESCRIPTION
This PR implements `PipelineTimingMetricTask`, which allows timing of pipelines that are linear or close to linear. It's designed to work on `ApPipe` or closely related pipelines (e.g., `ApVerify`), but is not a general-purpose tool.