### PR TITLE
DM-43414: Update make_apdb module for changes in APDB API

### DIFF
--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -1,7 +1,5 @@
 .. py:currentmodule:: lsst.ap.pipe
 
-.. program:: make_apdb.py
-
 .. _ap-pipe-apdb:
 
 ####################################################
@@ -10,15 +8,16 @@ Setting up the Alert Production Database for ap_pipe
 
 .. Centralized markup for program names
 
-.. |make_apdb| replace:: :doc:`make_apdb.py <scripts/make_apdb.py>`
+.. |apdb-cli| replace:: :command:`apdb-cli`
 
 .. |pipetask| replace:: :command:`pipetask`
 
 
 In its default configuration, the Alert Production Pipeline, as represented by :file:`pipelines/ApPipe.yaml`, relies on a database to save and load DIASources and DIAObjects.
 When running as part of the operational system, this database will be provided externally.
-However, during testing and development, developers can run |make_apdb| to set up their own database.
-This page provides an overview of how to use |make_apdb|.
+However, during testing and development, developers can run |apdb-cli| to set up their own database.
+This page provides an overview of how to use |apdb-cli|.
+Note that this document applies to APDB implementation backed by SQL database (SQLite or PostgreSQL), Cassandra-based implementation will use different set of options.
 
 .. _section-ap-pipe-apdb-config:
 
@@ -32,7 +31,7 @@ APDB configuration info uses the prefix ``diaPipe:apdb.``, with a colon, but is 
 
 Note that the `~lsst.dax.apdb.ApdbConfig.db_url` field has no default; a value *must* be provided by the user.
 
-Additionally, the default set of observed bands allowed to be used in the pipeline are set by the columns available in the Apdb schema specified by `~lsst.dax.ApdbConfig.schema_file` and `~lsst.dax.ApdbConfig.extra_schema_file`.
+Additionally, the default set of observed bands allowed to be used in the pipeline are set by the columns available in the Apdb schema specified by `~lsst.dax.ApdbConfig.schema_file`.
 Should the user wish to use the pipeline on data containing bands not in the ``ugrizy`` system, they must add the appropriate columns to the Apdb schema and add the bands to the ``validBands`` config in `~lsst.ap.association.DiaPipelineConig`.
 
 .. _section-ap-pipe-apdb-examples:
@@ -44,7 +43,7 @@ In Gen 3, this becomes (see :ref:`ap-pipe-pipeline-tutorial` for an explanation 
 
 .. prompt:: bash
 
-   make_apdb.py -c db_url="sqlite:///databases/apdb.db"
+   apdb-cli create-sql sqlite:///databases/apdb.db apdb_config.py
    pipetask run -p ApPipe.yaml -c diaPipe:apdb.db_url="sqlite:///databases/apdb.db" differencer:coaddName=dcr -b repo -o myrun
 
 .. warning::
@@ -52,26 +51,17 @@ In Gen 3, this becomes (see :ref:`ap-pipe-pipeline-tutorial` for an explanation 
    Make sure the APDB is created with a configuration consistent with the one used by the pipeline.
    Note that the pipeline file given by ``-p`` may include APDB config overrides of its own.
    You can double-check what configuration is being run by calling :command:`pipetask run` with the ``--show config="apdb*"`` argument, though this lists *all* configuration options, including those left at their defaults.
-   
+
+The ``apdb_config.py`` argument to |apdb-cli| specifies the name of the created configuration file that will contain serialized `~lsst.dax.apdb.ApdbConfig` for the new database.
+This file is not used yet by the ``pipetask`` options, but it will be used in the future.
+
 A Postgres database can be set up and used with the following:
 
 .. prompt:: bash
     
-   make_apdb.py -c db_url='postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl' -c namespace='my_apdb_name'
+   apdb-cli create-sql --namespace='my_apdb_name' 'postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl' apdb_config.py
    pipetask run -p ApPipe.yaml -c diaPipe:apdb.db_url='postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl' -c diaPipe:apdb.namespace='my_apdb_name' -d "my_data_query" -b repo -i my/input/collection -o my/output/collection
 
-Databases can also be set up using :ref:`config files <command-line-config-howto-configfile>`:
-
-.. code-block:: py
-   :caption: myApdbConfig.py
-
-   config.db_url = "sqlite:///databases/apdb.db"
-
-.. prompt:: bash
-
-   make_apdb.py -C myApdbConfig.py
-   pipetask run -p ApPipe.yaml -C myApPipeConfig.py  -b repo -o myrun
-   
 A Postgres database can be set up and used within :ref:`bps yaml files <creating-a-yaml-file>` by adding this to a submit yaml:
 
 .. code-block:: yaml
@@ -80,9 +70,9 @@ A Postgres database can be set up and used within :ref:`bps yaml files <creating
 
 .. prompt:: bash
 
-   make_apdb.py -c db_url='postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl' -c namespace='my_apdb_name'
+   apdb-cli create-sql --namespace='my_apdb_name' 'postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl' apdb_config.py
   
-Note that `make_apdb.py` must be run with the same `namespace` prior to submitting this bps yaml.
+Note that |apdb-cli| must be run with the same `namespace` prior to submitting this bps yaml.
   
 .. _section-ap-pipe-apdb-seealso:
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -38,7 +38,7 @@ To process your ingested data, run
 .. prompt:: bash
 
    mkdir apdb/
-   make_apdb.py -c db_url="sqlite:///apdb.db"
+   apdb-cli create-sql --db_url="sqlite:///apdb.db" apdb_config.py
    pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml \
        --register-dataset-types -c parameters:coaddName=deep \
        -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
@@ -47,7 +47,8 @@ To process your ingested data, run
        -d "visit in (411420, 419802) and detector=10"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
-See :doc:`apdb` for more information on :command:`make_apdb.py`.
+The ``apdb_config.py`` file will be created by ``apdb-cli``, it is not used yet by ``pipetask`` command options, but will be used in the future.
+See :doc:`apdb` for more information on :command:`apdb-cli`.
 
 This example command only processes observations corresponding to visits 411420 and 419802, both with only detector 10.
 

--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -1,9 +1,9 @@
 description: End to end AP pipeline specialized for DECam
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
-# (2) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (2) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:

--- a/pipelines/DECam/ApPipeCalibrate.yaml
+++ b/pipelines/DECam/ApPipeCalibrate.yaml
@@ -1,9 +1,9 @@
 description: End to end AP pipeline specialized for DECam
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
-# (2) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (2) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -2,15 +2,15 @@ description: DECam AP Pipeline with synthetic/fake sources. Templates are inputs
 # Remember:
 # (0) Ensure median calibration products and template coadds exist for the data being processed
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
-# (2) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (2) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs must match the make_apdb.py configs)
+#     (diaPipe configs must match the apdb-cli parameters)
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
-    exclude:  # These tasks frome from DECam's ApPipe.yaml instead
+    exclude:  # These tasks come from DECam's ApPipe.yaml instead
       - processCcd
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml
     include:  # All other tasks come from ApPipeWithFakes.yaml instead

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -1,8 +1,8 @@
 description: End to end AP pipeline specialized for HSC
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:

--- a/pipelines/HSC/ApPipeCalibrate.yaml
+++ b/pipelines/HSC/ApPipeCalibrate.yaml
@@ -1,8 +1,8 @@
 description: End to end AP pipeline specialized for HSC
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:

--- a/pipelines/HSC/ApPipeWithFakes.yaml
+++ b/pipelines/HSC/ApPipeWithFakes.yaml
@@ -1,10 +1,10 @@
 description: HSC AP Pipeline with synthetic/fake sources. Templates are inputs.
 # Remember:
 # (0) Ensure median calibration products and template coadds exist for the data being processed
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs must match the make_apdb.py configs)
+#     (diaPipe configs must match the apdb-cli parameters)
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:

--- a/pipelines/LSSTCam-imSim/ApPipe.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipe.yaml
@@ -1,8 +1,8 @@
 description: End to end AP pipeline specialized for ImSim.
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:

--- a/pipelines/LSSTCam-imSim/ApPipeCalibrate.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeCalibrate.yaml
@@ -1,8 +1,8 @@
 description: End to end AP pipeline specialized for ImSim
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:

--- a/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
@@ -1,9 +1,8 @@
 description: AP pipeline with synthetic/fakes sources specialized for ImSim
-# (1) Execute `make_apdb.py`, e.g.,
-#     make_apdb.py -c isolation_level=READ_UNCOMMITTED
-#                  -c db_url="sqlite:////project/user/association.db"
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
 # (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the make_apdb.py configs)
+#     (diaPipe configs should match the apdb-cli parameters)
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -3,7 +3,7 @@ description: End to end Alert Production pipeline.
 # for each camera. Those pipelines import this general AP pipeline.
 #
 # NOTES
-# Remember to run make_apdb.py and use the same configs for diaPipe
+# Remember to run `apdb-cli create-sql` and use the same configs for diaPipe
 # A db_url is always required, e.g.,
 # -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,

--- a/pipelines/_ingredients/ApPipeCalibrate.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrate.yaml
@@ -3,7 +3,7 @@ description: End to end Alert Production pipeline
 # for each camera. Those pipelines import this general AP pipeline.
 #
 # NOTES
-# Remember to run make_apdb.py and use the same configs for diaPipe
+# Remember to run `apdb-cli create-sql` and use the same configs for diaPipe
 # A db_url is always required, e.g.,
 # -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -116,8 +116,27 @@ def makeApdb(args=None):
     parser = ConfigOnlyParser()
     parsedCmd = parser.parse_args(args=args)
 
-    daxApdb.Apdb.makeSchema(parsedCmd.config)
-    apdb = daxApdb.make_apdb(config=parsedCmd.config)
+    # `make_apdb` is be replaced by `apdb-cli` commands, for now we keep it for
+    # backward compatibility, but only support SQL implementation here.
+    init_config = parsedCmd.config
+    if not isinstance(init_config, daxApdb.ApdbSqlConfig):
+        raise TypeError(f"Unexpected type of APDB configuration instance {type(init_config)}")
+    config = daxApdb.ApdbSql.init_database(
+        db_url=init_config.db_url,
+        schema_file=init_config.schema_file,
+        schema_name=init_config.schema_name,
+        read_sources_months=init_config.read_sources_months,
+        read_forced_sources_months=init_config.read_forced_sources_months,
+        use_insert_id=init_config.use_insert_id,
+        connection_timeout=init_config.connection_timeout,
+        dia_object_index=init_config.dia_object_index,
+        htm_level=init_config.htm_level,
+        htm_index_column=init_config.htm_index_column,
+        ra_dec_columns=init_config.ra_dec_columns,
+        prefix=init_config.prefix,
+        namespace=init_config.namespace,
+    )
+    apdb = daxApdb.Apdb.from_config(config)
     return apdb
 
 

--- a/python/lsst/ap/pipe/make_apdb.py
+++ b/python/lsst/ap/pipe/make_apdb.py
@@ -23,6 +23,8 @@ __all__ = ["makeApdb"]
 
 import argparse
 
+from deprecated.sphinx import deprecated
+
 import lsst.dax.apdb as daxApdb
 from lsst.pipe.base.configOverrides import ConfigOverrides
 from lsst.ap.association import DiaPipelineConfig
@@ -96,6 +98,14 @@ The config overrides must define ``db_url`` to create a valid config.
         return namespace
 
 
+@deprecated(
+    reason=(
+        "`make_apdb.py` script is deprecated, use `apdb-cli` command to create APDB instances. "
+        "Will be removed after v27"
+    ),
+    version="v27.0",
+    category=FutureWarning,
+)
 def makeApdb(args=None):
     """Create an APDB according to a config.
 
@@ -116,7 +126,7 @@ def makeApdb(args=None):
     parser = ConfigOnlyParser()
     parsedCmd = parser.parse_args(args=args)
 
-    # `make_apdb` is be replaced by `apdb-cli` commands, for now we keep it for
+    # `make_apdb` is replaced by `apdb-cli` commands, for now we keep it for
     # backward compatibility, but only support SQL implementation here.
     init_config = parsedCmd.config
     if not isinstance(init_config, daxApdb.ApdbSqlConfig):


### PR DESCRIPTION
`make_apdb` will be replaced by `apdb-cli` sub-command, for now we keep it for compatibility reasons, but update it for new APDB API. This script depends on using pex_config for Apdb configuration, that will be replaced eventually with something different, we may want to drop this script before that change.