### PR TITLE
DM-43711: Add contracts for analysis_tools plots

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -122,6 +122,9 @@ contracts:
   - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
               diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
     msg: "detectAndMeasure.subtractedMeasuredExposure != diaPipe.diffIm"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).spatiallySampledMetrics.name ==
+              diffimTaskPlots.connections.ConnectionsClass(config=diffimTaskPlots).data.name
+    msg: "detectAndMeasure.spatiallySampledMetrics != diffimTaskPlots.data"
   - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
               rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
     msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
@@ -135,3 +138,9 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
     msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
+              analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
+    msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"
+  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).longTrailedSources.name ==
+              analyzeTrailedDiaSrcCore.connections.ConnectionsClass(config=analyzeTrailedDiaSrcCore).data.name
+    msg: "diaPipe.longTrailedSources != analyzeTrailedDiaSrcCore.data"

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -167,6 +167,9 @@ contracts:
   - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
               fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
     msg: "detectAndMeasure.subtractedMeasuredExposure != fakesMatch.diffIm"
+  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).spatiallySampledMetrics.name ==
+              diffimTaskPlots.connections.ConnectionsClass(config=diffimTaskPlots).data.name
+    msg: "detectAndMeasure.spatiallySampledMetrics != diffimTaskPlots.spatiallySampledMetrics"
   - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
               rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
     msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
@@ -183,3 +186,9 @@ contracts:
   - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
               fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
     msg: "diaPipe.associatedDiaSources != fakesMatch.associatedDiaSources"
+  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
+              analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
+    msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"
+  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).longTrailedSources.name ==
+              analyzeTrailedDiaSrcCore.connections.ConnectionsClass(config=analyzeTrailedDiaSrcCore).data.name
+    msg: "diaPipe.longTrailedSources != analyzeTrailedDiaSrcCore.data"


### PR DESCRIPTION
Note that most analysis_tools Tasks require the input connections to be named 'data'