### PR TITLE
DM-43020: Implement region and time extraction for preload

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -60,6 +60,10 @@ tasks:
       doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
       doIncludeReliability: True  # Output from rbClassify
+  getRegionTimeFromVisit:
+    class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
+    config:
+      connections.coaddName: parameters.coaddName
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
@@ -83,6 +87,7 @@ subsets:
       - filterDiaSrcCat
       - rbClassify
       - transformDiaSrcCat
+      - getRegionTimeFromVisit
       - diaPipe
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
@@ -164,6 +169,10 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
     msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+  # Run getRegionTimeFromVisit as late as possible
+  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "transformDiaSrcCat.diaSourceTable != getRegionTimeFromVisit.dummy_visit"
   - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
               analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
     msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"

--- a/pipelines/_ingredients/ApPipeCalibrate.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrate.yaml
@@ -53,6 +53,10 @@ tasks:
       doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
       doIncludeReliability: True  # Output from rbClassify
+  getRegionTimeFromVisit:
+    class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
+    config:
+      connections.coaddName: parameters.coaddName
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
@@ -70,6 +74,7 @@ subsets:
       - detectAndMeasure
       - rbClassify
       - transformDiaSrcCat
+      - getRegionTimeFromVisit
       - diaPipe
       - filterDiaSrcCat
     description: >
@@ -119,3 +124,7 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
     msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+  # Run getRegionTimeFromVisit as late as possible
+  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "transformDiaSrcCat.diaSourceTable != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -84,6 +84,11 @@ tasks:
       connections.fakesType: parameters.fakesType
       doRemoveSkySources: True
       doIncludeReliability: True  # Output from rbClassify
+  getRegionTimeFromVisit:
+    class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
+    config:
+      connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
@@ -120,6 +125,7 @@ subsets:
       - filterDiaSrcCat
       - rbClassify
       - transformDiaSrcCat
+      - getRegionTimeFromVisit
       - diaPipe
       - fakesMatch
       - sampleSpatialMetrics
@@ -208,6 +214,10 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
     msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+  # Run getRegionTimeFromVisit as late as possible
+  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "transformDiaSrcCat.diaSourceTable != getRegionTimeFromVisit.dummy_visit"
   - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
               fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
     msg: "diaPipe.associatedDiaSources != fakesMatch.associatedDiaSources"


### PR DESCRIPTION
This PR adds the `GetRegionTimeFromVisitTask` from lsst/pipe_tasks#920 to the AP pipelines.

The use of a contract for its input connections is a bit questionable, since the task does not actually use the input catalog for anything and so it's somewhat interchangeable. For now, the contract enforces that the task be run as late as possible, to minimize inconsistencies from parallel reads and writes to the APDB.

Important: this PR should not be merged until `/repo/main` has been migrated to dimensions-config `daf_butler` 6 or later; otherwise, it will break AP precursor processing.