### PR TITLE
DM-43416: Migrate AP code to external APDB configs

### DIFF
--- a/doc/lsst.ap.pipe/apdb.rst
+++ b/doc/lsst.ap.pipe/apdb.rst
@@ -13,7 +13,7 @@ Setting up the Alert Production Database for ap_pipe
 .. |pipetask| replace:: :command:`pipetask`
 
 
-In its default configuration, the Alert Production Pipeline, as represented by :file:`pipelines/ApPipe.yaml`, relies on a database to save and load DIASources and DIAObjects.
+In its default configuration, the Alert Production Pipeline, as represented by :file:`pipelines/_ingredients/ApPipe.yaml`, relies on a database to save and load DIASources and DIAObjects.
 When running as part of the operational system, this database will be provided externally.
 However, during testing and development, developers can run |apdb-cli| to set up their own database.
 This page provides an overview of how to use |apdb-cli|.
@@ -29,10 +29,10 @@ The database is configured using `~lsst.dax.apdb.ApdbConfig`.
 For |pipetask| users, the APDB is configured with the :option:`--config <pipetask run --config>` and :option:`--config-file <pipetask run --config-file>` options.
 APDB configuration info uses the prefix ``diaPipe:apdb.``, with a colon, but is otherwise the same.
 
-Note that the `~lsst.dax.apdb.ApdbConfig.db_url` field has no default; a value *must* be provided by the user.
+Note that the `~lsst.dax.apdb.ApdbSqlConfig.db_url` field has no default; a value *must* be provided by the user.
 
-Additionally, the default set of observed bands allowed to be used in the pipeline are set by the columns available in the Apdb schema specified by `~lsst.dax.ApdbConfig.schema_file`.
-Should the user wish to use the pipeline on data containing bands not in the ``ugrizy`` system, they must add the appropriate columns to the Apdb schema and add the bands to the ``validBands`` config in `~lsst.ap.association.DiaPipelineConig`.
+Additionally, the default set of observed bands allowed to be used in the pipeline are set by the columns available in the Apdb schema specified by `~lsst.dax.apdb.ApdbConfig.schema_file`.
+Should the user wish to use the pipeline on data containing bands not in the ``ugrizy`` system, they must add the appropriate columns to the Apdb schema and add the bands to the ``validBands`` config in `~lsst.ap.association.DiaPipelineConfig`.
 
 .. _section-ap-pipe-apdb-examples:
 

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -4,9 +4,9 @@
 
 .. _ap-pipe-getting-started-gen3:
 
-############################################
-Getting started with the AP pipeline (Gen 3)
-############################################
+####################################
+Getting started with the AP pipeline
+####################################
 
 This page explains how to set up a Gen 3 data repository that can then be processed with the AP Pipeline (see :doc:`pipeline-tutorial`).
 This is appropriate if you are trying to learn the new workflow, and compatibility or integration with other tools is not a problem.

--- a/doc/lsst.ap.pipe/index.rst
+++ b/doc/lsst.ap.pipe/index.rst
@@ -46,7 +46,7 @@ Contributing
 ============
 
 ``lsst.ap.pipe`` is developed at https://github.com/lsst/ap_pipe.
-You can find Jira issues for this module under the `ap_pipe <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_pipe>`_ component.
+You can find Jira issues for this module under the `ap_pipe <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_pipe>`_ component.
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -37,17 +37,16 @@ To process your ingested data, run
 
 .. prompt:: bash
 
-   mkdir apdb/
-   apdb-cli create-sql --db_url="sqlite:///apdb.db" apdb_config.py
+   apdb-cli create-sql "sqlite:///apdb.db" apdb_config.py
    pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml \
        --register-dataset-types -c parameters:coaddName=deep \
        -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
-       -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
+       -c parameters:apdb_config=apdb_config.py -b repo/ \
        -i "DECam/defaults,DECam/raw/all" -o processed \
        -d "visit in (411420, 419802) and detector=10"
 
 In this case, a ``processed/<timestamp>`` collection will be created within ``repo`` and the results will be written there.
-The ``apdb_config.py`` file will be created by ``apdb-cli``, it is not used yet by ``pipetask`` command options, but will be used in the future.
+The ``apdb_config.py`` file will be created by ``apdb-cli`` and passed to ``pipetask``.
 See :doc:`apdb` for more information on :command:`apdb-cli`.
 
 This example command only processes observations corresponding to visits 411420 and 419802, both with only detector 10.
@@ -60,20 +59,19 @@ If you prefer to have a standalone output collection, you may instead run
    pipetask run -p ${AP_PIPE_DIR}/pipelines/DECam/ApPipe.yaml \
        --register-dataset-types -c parameters:coaddName=deep \
        -c isr:connections.bias=cpBias -c isr:connections.flat=cpFlat \
-       -c diaPipe:apdb.db_url="sqlite:///apdb.db" -b repo/ \
+       -c parameters:apdb_config=apdb_config.py -b repo/ \
        -i "DECam/defaults,DECam/raw/all" --output-run processed \
        -d "visit in (411420, 419802) and detector=10"
 
 .. note::
 
-   You must :doc:`configure </modules/lsst.ctrl.mpexec/configuring-pipetask-tasks>` the database location, or ``ap_pipe`` will not run.
-   For the default (SQLite) association database, the location is a path to a new or existing database file to be used for source associations (including associations with previously known objects, if the database already exists).
-   In the examples above, it is configured with the ``-c`` option, but a personal config file may be more convenient if you intend to run ``ap_pipe`` many times.
+   You must :doc:`configure </modules/lsst.ctrl.mpexec/configuring-pipetask-tasks>` the pipeline to use the APDB config file, or ``ap_pipe`` will not run.
+   In the examples above, it is configured with the ``-c`` option.
 
 .. note::
 
    Both examples above are only valid when running the pipeline for the first time.
-   When rerunning with an existing chained collection using ``-o``, you must omit the ``-i`` argument.
+   When rerunning with an existing chained collection using ``-o``, you should omit the ``-i`` argument.
    When rerunning with an existing standalone collection using ``--output-run``, you must pass ``--extend-run``.
 
 .. _section-ap-pipe-expected-outputs:

--- a/doc/lsst.ap.pipe/pipeline-tutorial.rst
+++ b/doc/lsst.ap.pipe/pipeline-tutorial.rst
@@ -4,9 +4,9 @@
 
 .. _ap-pipe-pipeline-tutorial-gen3:
 
-###############################
-Running the AP pipeline (Gen 3)
-###############################
+#######################
+Running the AP pipeline
+#######################
 
 Setup
 =====

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -21,6 +21,8 @@ imports:
 parameters:
   # Pipeline configurable to run on both goodSeeing and deep templates, depending on dataset.
   coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
 tasks:
   retrieveTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
@@ -61,6 +63,8 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      doConfigureApdb: False
+      apdb_config_url: parameters.apdb_config
       connections.exposure: initial_pvi
       connections.coaddName: parameters.coaddName
   sampleSpatialMetrics:

--- a/pipelines/_ingredients/ApPipeCalibrate.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrate.yaml
@@ -20,6 +20,8 @@ imports:
 parameters:
   # Pipeline configurable to run on both goodSeeing and deep templates, depending on dataset.
   coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
 tasks:
   retrieveTemplate:  # For multi-tract difference imaging
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
@@ -54,6 +56,8 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      doConfigureApdb: False
+      apdb_config_url: parameters.apdb_config
       connections.coaddName: parameters.coaddName
 subsets:
   apPipe:

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -23,6 +23,8 @@ imports:
 parameters:
   coaddName: goodSeeing
   fakesType: 'fakes_'
+  # APDB config file must be user-specified
+  apdb_config:
 
 tasks:
   createFakes:
@@ -86,9 +88,10 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doWriteAssociatedSources: True
+      doConfigureApdb: False
+      apdb_config_url: parameters.apdb_config
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
   sampleSpatialMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -52,8 +52,7 @@ class PipelineDefintionsTestSuite(lsst.utils.tests.TestCase):
                 continue
             with self.subTest(file):
                 pipeline = lsst.pipe.base.Pipeline.from_uri(file)
-                if "apPipe" in pipeline.subsets:
-                    pipeline.addConfigOverride("diaPipe", "apdb.db_url", "sqlite://")
+                pipeline.addConfigOverride("parameters", "apdb_config", "some/file/path.yaml")
                 # If this fails, it will produce a useful error message.
                 pipeline.to_graph()
 
@@ -84,7 +83,7 @@ class PipelineDefintionsTestSuite(lsst.utils.tests.TestCase):
                     },
                     # Pipeline outputs highly in flux, don't test
                     expected_outputs=set(),
-                    pipeline_patches={"diaPipe:apdb.db_url": "sqlite://",
+                    pipeline_patches={"parameters:apdb_config": "some/file/path.yaml",
                                       },
                 )
                 # Tester modifies Butler registry, so need a fresh repo every time


### PR DESCRIPTION
This PR modifies the AP pipelines to use new-style configs instead of the `diaPipe.apdb` field. It must be merged after lsst/ap_association#210. This is a major API change to the pipeline, and the documentation has been updated accordingly.