### PR TITLE
DM-44411: Fix bit-rot in AP pipelines

### DIFF
--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -2,8 +2,7 @@ description: End to end AP pipeline specialized for DECam
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
 # (2) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (3) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:

--- a/pipelines/DECam/ApPipeCalibrate.yaml
+++ b/pipelines/DECam/ApPipeCalibrate.yaml
@@ -2,8 +2,7 @@ description: End to end AP pipeline specialized for DECam
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
 # (2) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (3) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -4,8 +4,7 @@ description: DECam AP Pipeline with synthetic/fake sources. Templates are inputs
 # (1) Run $AP_PIPE_DIR/pipelines/DECam/RunIsrForCrosstalkSources.yaml
 # (2) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (3) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs must match the apdb-cli parameters)
+# (3) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
@@ -16,8 +15,5 @@ imports:
     include:  # All other tasks come from ApPipeWithFakes.yaml instead
       - processCcd
 
-tasks:
-  diaPipe:
-    class: lsst.ap.association.DiaPipelineTask
-    config:
-      # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
+parameters:
+  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -10,9 +10,9 @@ description: DECam AP Pipeline with synthetic/fake sources. Templates are inputs
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
-    exclude:  # These tasks come from DECam's ApPipe.yaml instead
+    exclude:  # These tasks come from DECam's ProcessCcdCalibrate.yaml instead
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcdCalibrate.yaml
     include:  # All other tasks come from ApPipeWithFakes.yaml instead
       - processCcd
 

--- a/pipelines/DECam/ApTemplate.yaml
+++ b/pipelines/DECam/ApTemplate.yaml
@@ -4,9 +4,9 @@ description: The AP template building pipeline specialized for DECam
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
-  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcd.yaml
+  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcdCalibrate.yaml
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApTemplate.yaml
-    exclude:  # These tasks come from DECam/ProcessCcd.yaml instead
+    exclude:  # These tasks come from DECam/ProcessCcdCalibrate.yaml instead
       - processCcd
 
 subsets:

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -1,8 +1,7 @@
 description: End to end AP pipeline specialized for HSC
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:

--- a/pipelines/HSC/ApPipeCalibrate.yaml
+++ b/pipelines/HSC/ApPipeCalibrate.yaml
@@ -1,8 +1,7 @@
 description: End to end AP pipeline specialized for HSC
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:

--- a/pipelines/HSC/ApPipeWithFakes.yaml
+++ b/pipelines/HSC/ApPipeWithFakes.yaml
@@ -9,9 +9,9 @@ description: HSC AP Pipeline with synthetic/fake sources. Templates are inputs.
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
-    exclude:  # These tasks frome from HSC's ApPipe.yaml instead
+    exclude:  # These tasks frome from HSC's ProcessCcdCalibrate.yaml instead
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/HSC/ProcessCcdCalibrate.yaml
     include:  # All other tasks come from _ingredients/ApPipeWithFakes.yaml instead
       - processCcd
 

--- a/pipelines/HSC/ApPipeWithFakes.yaml
+++ b/pipelines/HSC/ApPipeWithFakes.yaml
@@ -3,8 +3,7 @@ description: HSC AP Pipeline with synthetic/fake sources. Templates are inputs.
 # (0) Ensure median calibration products and template coadds exist for the data being processed
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs must match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
@@ -15,6 +14,8 @@ imports:
     include:  # All other tasks come from _ingredients/ApPipeWithFakes.yaml instead
       - processCcd
 
+parameters:
+  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
 tasks:
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
@@ -30,7 +31,3 @@ tasks:
       connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: 'isVisitSource'
-  diaPipe:
-    class: lsst.ap.association.DiaPipelineTask
-    config:
-      # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE

--- a/pipelines/HSC/ApTemplate.yaml
+++ b/pipelines/HSC/ApTemplate.yaml
@@ -3,9 +3,9 @@ description: The AP template building pipeline specialized for HSC
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
-  - location: $AP_PIPE_DIR/pipelines/HSC/ProcessCcd.yaml
+  - location: $AP_PIPE_DIR/pipelines/HSC/ProcessCcdCalibrate.yaml
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApTemplate.yaml
-    exclude:  # These tasks come from HSC/ProcessCcd.yaml instead
+    exclude:  # These tasks come from HSC/ProcessCcdCalibrate.yaml instead
       - processCcd
 
 tasks:

--- a/pipelines/LSSTCam-imSim/ApPipe.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipe.yaml
@@ -1,8 +1,7 @@
 description: End to end AP pipeline specialized for ImSim.
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:

--- a/pipelines/LSSTCam-imSim/ApPipeCalibrate.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeCalibrate.yaml
@@ -1,8 +1,7 @@
 description: End to end AP pipeline specialized for ImSim
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:

--- a/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
@@ -1,8 +1,7 @@
 description: AP pipeline with synthetic/fakes sources specialized for ImSim
 # (1) Execute `apdb-cli create-sql`, e.g.,
 #     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
-# (2) Run this pipeline, setting appropriate diaPipe configs
-#     (diaPipe configs should match the apdb-cli parameters)
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:
@@ -13,8 +12,5 @@ imports:
     include:  # All other tasks come from the ApPipeWithFakes.yaml
       - processCcd
 
-tasks:
-  diaPipe:
-    class: lsst.ap.association.DiaPipelineTask
-    config:
-      # apdb.db_url: YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
+parameters:
+  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE

--- a/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
@@ -7,9 +7,9 @@ description: AP pipeline with synthetic/fakes sources specialized for ImSim
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
-    exclude:  # These tasks come from LsstCamImSim/ApPipe.yaml instead
+    exclude:  # These tasks come from LsstCamImSim/ProcessCcdCalibrate.yaml instead
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcdCalibrate.yaml
     include:  # All other tasks come from the ApPipeWithFakes.yaml
       - processCcd
 

--- a/pipelines/LSSTCam-imSim/ApTemplate.yaml
+++ b/pipelines/LSSTCam-imSim/ApTemplate.yaml
@@ -3,9 +3,9 @@ description: The AP template building pipeline specialized for ImSim
 
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:
-  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcd.yaml
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcdCalibrate.yaml
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApTemplate.yaml
-    exclude:  # These tasks come from LSSTCam-imSim/ProcessCcd.yaml instead
+    exclude:  # These tasks come from LSSTCam-imSim/ProcessCcdCalibrate.yaml instead
       - processCcd
 
 tasks:

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -3,11 +3,9 @@ description: End to end Alert Production pipeline.
 # for each camera. Those pipelines import this general AP pipeline.
 #
 # NOTES
-# Remember to run `apdb-cli create-sql` and use the same configs for diaPipe
-# A db_url is always required, e.g.,
-# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
+# Remember to run `apdb-cli create-sql`
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
-# -c diaPipe:apdb.connection_timeout: 240
+# --connection_timeout 240
 
 # WARNING: camera-specific pipelines importing this pipeline may
 # blow away all the configs that are set in this file.

--- a/pipelines/_ingredients/ApPipeCalibrate.yaml
+++ b/pipelines/_ingredients/ApPipeCalibrate.yaml
@@ -3,11 +3,9 @@ description: End to end Alert Production pipeline
 # for each camera. Those pipelines import this general AP pipeline.
 #
 # NOTES
-# Remember to run `apdb-cli create-sql` and use the same configs for diaPipe
-# A db_url is always required, e.g.,
-# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
+# Remember to run `apdb-cli create-sql`
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
-# -c diaPipe:apdb.connection_timeout: 240
+# --connection_timeout 240
 
 # WARNING: camera-specific pipelines importing this pipeline may
 # blow away all the configs that are set in this file.

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -41,10 +41,10 @@ class PipelineDefintionsTestSuite(lsst.utils.tests.TestCase):
         self.path = os.path.join(lsst.utils.getPackageDir("ap_pipe"), "pipelines")
 
     def test_graph_build(self):
-        """Test that each pipeline definition file in `_ingredients/` can be
+        """Test that each pipeline definition file can be
         used to build a graph.
         """
-        files = glob.glob(os.path.join(self.path, "_ingredients/*.yaml"))
+        files = glob.glob(os.path.join(self.path, "**", "*.yaml"))
         for file in files:
             if "ApTemplate" in file:
                 # Our ApTemplate definition cannot be tested here because it
@@ -57,7 +57,7 @@ class PipelineDefintionsTestSuite(lsst.utils.tests.TestCase):
                 pipeline.to_graph()
 
     def test_datasets(self):
-        files = glob.glob(os.path.join(self.path, "_ingredients/*.yaml"))
+        files = glob.glob(os.path.join(self.path, "_ingredients", "*.yaml"))
         for file in files:
             if "ApTemplate" in file:
                 # Our ApTemplate definition cannot be tested here because it

--- a/ups/ap_pipe.table
+++ b/ups/ap_pipe.table
@@ -15,5 +15,10 @@ setupRequired(analysis_tools)
 
 setupRequired(meas_transiNet)
 
+# For testing instrument pipelines
+setupRequired(obs_decam)
+setupRequired(obs_subaru)
+setupRequired(obs_lsst)
+
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This PR fixes a number of self-consistency problems with the AP pipelines, related to the migration from `characterizeImage`/`calibrate` to `calibrateImage` (#166). It also removes references to the old APDB configuration system (something I should have done on #182).