### PR TITLE
DM-44796: Replace deprecated getInnerSkyPolygon() with getOuterSkyPolygon()

### DIFF
--- a/python/lsst/ap/pipe/createApFakes.py
+++ b/python/lsst/ap/pipe/createApFakes.py
@@ -147,7 +147,7 @@ class CreateRandomApFakesTask(PipelineTask):
         # Use the tractId as the ranomd seed.
         rng = np.random.default_rng(tractId)
         tractBoundingCircle = \
-            skyMap.generateTract(tractId).getInnerSkyPolygon().getBoundingCircle()
+            skyMap.generateTract(tractId).getOuterSkyPolygon().getBoundingCircle()
         tractArea = tractBoundingCircle.getArea() * (180 / np.pi) ** 2
         nFakes = int(self.config.fakeDensity * tractArea)
 

--- a/tests/test_createApFakes.py
+++ b/tests/test_createApFakes.py
@@ -47,7 +47,7 @@ class TestCreateApFakes(lsst.utils.tests.TestCase):
 
         self.simpleMap = skyMap.DiscreteSkyMap(simpleMapConfig)
         self.tractId = 0
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         self.nSources = 10
         self.sourceDensity = (self.nSources
                               / (bCircle.getArea() * (180 / np.pi) ** 2))
@@ -100,7 +100,7 @@ class TestCreateApFakes(lsst.utils.tests.TestCase):
         fakesConfig.fraction = 0.5
         fakesConfig.fakeDensity = self.sourceDensity
         fakesTask = CreateRandomApFakesTask(config=fakesConfig)
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         result = fakesTask.run(self.tractId, self.simpleMap)
         fakeCat = result.fakeCat
         self.assertEqual(len(fakeCat), self.nSources)
@@ -127,7 +127,7 @@ class TestCreateApFakes(lsst.utils.tests.TestCase):
         contained in the cap bound.
         """
         fakesTask = CreateRandomApFakesTask()
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
 
         randData = fakesTask.createRandomPositions(
             nFakes=self.nSources,
@@ -147,7 +147,7 @@ class TestCreateApFakes(lsst.utils.tests.TestCase):
         a test vector to the expected location.
         """
         createFakes = CreateRandomApFakesTask()
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         rotMatrix = createFakes._createRotMatrix(bCircle)
         rotatedVector = np.dot(rotMatrix, np.array([0, 0, 1]))
         expectedVect = bCircle.getCenter()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -69,7 +69,7 @@ class TestApCompletenessTask(MetricTaskTestCase):
 
         self.simpleMap = skyMap.DiscreteSkyMap(simpleMapConfig)
         self.tractId = 0
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         self.targetSources = 1000
         self.sourceDensity = (self.targetSources
                               / (bCircle.getArea() * (180 / np.pi) ** 2))
@@ -146,7 +146,7 @@ class TestApCountTask(MetricTaskTestCase):
 
         self.simpleMap = skyMap.DiscreteSkyMap(simpleMapConfig)
         self.tractId = 0
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         self.targetSources = 1000
         self.sourceDensity = (self.targetSources
                               / (bCircle.getArea() * (180 / np.pi) ** 2))


### PR DESCRIPTION
Note that (a) for rings and discrete skymap these return almost the same polygon (which was incorrect necessitating the deprecation); (b) using the outer polygon may have been the original intention in this task; (c) this task is soon to be deprecated and removed on DM-40855.
