### PR TITLE
DM-42576: Write task to compute predicted positions for an upcoming visit

### DIFF
--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -25,6 +25,7 @@ subsets:
       - rbClassify
       - transformDiaSrcCat
       - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
       - diaPipe
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
@@ -37,6 +38,7 @@ subsets:
   preload:
     subset:
       - loadDiaCatalogs
+      - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
     subset:

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -35,6 +35,7 @@ subsets:
       - rbClassify
       - transformDiaSrcCat
       - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
       - diaPipe
       - injectedMatch
       - sampleSpatialMetrics
@@ -48,6 +49,7 @@ subsets:
   preload:
     subset:
       - loadDiaCatalogs
+      - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
     subset:

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -29,6 +29,7 @@ subsets:
       - filterDiaSrcCat
       - transformDiaSrcCat
       - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
       - diaPipe
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -67,6 +67,8 @@ tasks:
     class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
     config:
       connections.coaddName: parameters.coaddName
+  mpSkyEphemerisQuery:
+    class: lsst.ap.association.MPSkyEphemerisQueryTask
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
@@ -79,6 +81,7 @@ tasks:
     config:
       connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
+
 subsets:
   apPipe:
     subset:
@@ -92,6 +95,7 @@ subsets:
       - rbClassify
       - transformDiaSrcCat
       - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery      
       - diaPipe
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
@@ -104,6 +108,7 @@ subsets:
   preload:
     subset:
       - loadDiaCatalogs
+      - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
     subset:
@@ -220,9 +225,18 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
     msg: "transformDiaSrcCat.diaSourceTable != getRegionTimeFromVisit.dummy_visit"
+  - contract: getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).output.name ==
+              mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).predictedRegionTime.name
+    msg: "mpSkyEphemerisQuery.predictedRegionTime != getRegionTimeFromVisit.output"    
+  - contract: (not diaPipe.doSolarSystemAssociation) or
+              (mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).ssObjects.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).solarSystemObjectTable.name)
+    msg: "mpSkyEphemerisQuery.ssObjects != diaPipe.solarSystemObjectTable"        
   - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
               analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
     msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"
   - contract: sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).spatiallySampledMetrics.name ==
               diffimTaskPlots.connections.ConnectionsClass(config=diffimTaskPlots).data.name
     msg: "sampleSpatialMetrics.spatiallySampledMetrics != diffimTaskPlots.data"
+
+

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -86,6 +86,8 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+  mpSkyEphemerisQuery:
+    class: lsst.ap.association.MPSkyEphemerisQueryTask      
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
@@ -136,6 +138,7 @@ subsets:
       - rbClassify
       - transformDiaSrcCat
       - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery      
       - diaPipe
       - injectedMatch
       - consolidateMatchDiaSrc
@@ -152,6 +155,7 @@ subsets:
   preload:
     subset:
       - loadDiaCatalogs
+      - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
     subset:
@@ -265,6 +269,13 @@ contracts:
   - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
               getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
     msg: "transformDiaSrcCat.diaSourceTable != getRegionTimeFromVisit.dummy_visit"
+  - contract: getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).output.name ==
+              mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).predictedRegionTime.name
+    msg: "mpSkyEphemerisQuery.predictedRegionTime != getRegionTimeFromVisit.output"    
+  - contract: (not diaPipe.doSolarSystemAssociation) or
+              (mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).ssObjects.name ==
+              diaPipe.connections.ConnectionsClass(config=diaPipe).solarSystemObjectTable.name)
+    msg: "mpSkyEphemerisQuery.ssObjects != diaPipe.solarSystemObjectTable"            
   - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
               analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
     msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"


### PR DESCRIPTION
Adding mpSkyEphemerisQuery, which replaces SkyBot in querying mpSky for ssObjects in the pre-load step.