### PR TITLE
DM-43418: Divide AP pipeline into preload and prompt subsets

### DIFF
--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -11,7 +11,7 @@ imports:
     exclude:  # These tasks come from DECam/ProcessCcd.yaml instead
       - processCcd
 subsets:
-# apPipe must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+# apPipe, preload, and prompt must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
 # because its processCcd was excluded.
   apPipe:
     subset:
@@ -34,3 +34,25 @@ subsets:
       - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.
+  preload:
+    subset:
+      - loadDiaCatalogs
+    description: Tasks that can be run before receiving raw images.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - rbClassify
+      - transformDiaSrcCat
+      - diaPipe
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - initialPviCore
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.

--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -21,11 +21,16 @@ subsets:
       - retrieveTemplate
       - subtractImages
       - detectAndMeasure
+      - filterDiaSrcCat
       - rbClassify
       - transformDiaSrcCat
+      - getRegionTimeFromVisit
       - diaPipe
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
+      - sampleSpatialMetrics
       - diffimTaskCore
+      - diffimTaskPlots
+      - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -20,7 +20,7 @@ parameters:
   injected_prefix: "fakes_"
   injection_prefix: "injection_"
 subsets:
-# apPipe must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+# apPipe, preload, and prompt must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
 # because its processCcd was excluded.
   apPipe:
     subset:
@@ -36,6 +36,7 @@ subsets:
       - transformDiaSrcCat
       - getRegionTimeFromVisit
       - diaPipe
+      - injectedMatch
       - sampleSpatialMetrics
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
@@ -44,3 +45,26 @@ subsets:
       - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.
+  preload:
+    subset:
+      - loadDiaCatalogs
+    description: Tasks that can be run before receiving raw images.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - rbClassify
+      - transformDiaSrcCat
+      - diaPipe
+      - injectedMatch
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - initialPviCore
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -8,7 +8,10 @@ description: DECam AP Pipeline with synthetic/fake sources. Templates are inputs
 
 instrument: lsst.obs.decam.DarkEnergyCamera
 imports:
+  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcd.yaml
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+    exclude:  # These tasks come from DECam/ProcessCcd.yaml instead
+      - processCcd
 
 parameters:
   apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
@@ -16,3 +19,28 @@ parameters:
   fakesType: 'fakes_'
   injected_prefix: "fakes_"
   injection_prefix: "injection_"
+subsets:
+# apPipe must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+# because its processCcd was excluded.
+  apPipe:
+    subset:
+      - inject_visit
+      - loadDiaCatalogs
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - rbClassify
+      - transformDiaSrcCat
+      - getRegionTimeFromVisit
+      - diaPipe
+      - sampleSpatialMetrics
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - diffimTaskPlots
+      - initialPviCore
+    description: >
+      An alias of ApPipe to use in higher-level pipelines.

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -6,12 +6,12 @@ instrument: lsst.obs.lsst.LsstComCamSim
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
     exclude:
-      # TODO: prompt_prototype does not yet support R/B analysis: DM-42220.
+      # turn off R/B analysis to save processing time
       - rbClassify
 
 tasks:
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
-      # TODO: prompt_prototype does not yet support R/B analysis: DM-42220.
+      # turn off R/B analysis to save processing time
       doIncludeReliability: False

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -101,6 +101,35 @@ subsets:
       - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.
+  preload:
+    subset:
+      - loadDiaCatalogs
+    description: Tasks that can be run before receiving raw images.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - rbClassify
+      - transformDiaSrcCat
+      - diaPipe
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - initialPviCore
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.
+  afterburner:
+    subset:
+      - sampleSpatialMetrics
+      - diffimTaskPlots
+    description: >
+      Tasks for QA and other non-real-time processing.
+      Requires prompt subset to be run first.
 contracts:
   - detectAndMeasure.doSkySources == transformDiaSrcCat.doRemoveSkySources
   # Both loadDiaCatalogs and diaPipe connect to the APDB, so make sure they use the same configuration

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -138,6 +138,37 @@ subsets:
       - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.
+  preload:
+    subset:
+      - loadDiaCatalogs
+    description: Tasks that can be run before receiving raw images.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - inject_visit
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - rbClassify
+      - transformDiaSrcCat
+      - diaPipe
+      - injectedMatch
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - initialPviCore
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.
+  afterburner:
+    subset:
+      - sampleSpatialMetrics
+      - diffimTaskPlots
+    description: >
+      Tasks for QA and other non-real-time processing.
+      Requires prompt subset to be run first.
   injected_processCcd:
     subset:
     - inject_visit

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -112,11 +112,13 @@ tasks:
 subsets:
   processCcd:
     subset:
-    - isr
-    - calibrateImage
+      - isr
+      - calibrateImage
     description: 'An alias of ProcessCcd to use in higher-level pipelines.'
   apPipe:
     subset:
+      - isr
+      - calibrateImage
       - inject_visit
       - loadDiaCatalogs
       - retrieveTemplate
@@ -127,11 +129,13 @@ subsets:
       - transformDiaSrcCat
       - getRegionTimeFromVisit
       - diaPipe
+      - injectedMatch
       - sampleSpatialMetrics
       - analyzeAssocDiaSrcCore
       - analyzeTrailedDiaSrcCore
       - diffimTaskCore
       - diffimTaskPlots
+      - initialPviCore
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   injected_processCcd:


### PR DESCRIPTION
This PR divides the AP pipelines into `preload`, `prompt`, and `afterburner` subsets, and ensures the pipeline variants are mutually consistent.