### PR TITLE
DM-43418: Divide AP pipeline into preload and prompt subsets

### DIFF
--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -15,3 +15,43 @@ tasks:
     config:
       # turn off R/B analysis to save processing time
       doIncludeReliability: False
+subsets:
+# apPipe and prompt must be redefined from $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+# because its rbClassify was excluded.
+  apPipe:
+    subset:
+      - loadDiaCatalogs
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - transformDiaSrcCat
+      - getRegionTimeFromVisit
+      - diaPipe
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - sampleSpatialMetrics
+      - diffimTaskCore
+      - diffimTaskPlots
+      - initialPviCore
+    description: >
+      An alias of ApPipe to use in higher-level pipelines.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - retrieveTemplate
+      - subtractImages
+      - detectAndMeasure
+      - filterDiaSrcCat
+      - transformDiaSrcCat
+      - diaPipe
+      - analyzeAssocDiaSrcCore
+      - analyzeTrailedDiaSrcCore
+      - diffimTaskCore
+      - initialPviCore
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.


### PR DESCRIPTION
This PR fixes a bug overlooked in #191, where the ComCamSim specialization of ApPipe is missing the `apPipe` and `prompt` subsets