### PR TITLE
DM-46050: Use average PSF for packaged alerts

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -75,6 +75,7 @@ tasks:
       doConfigureApdb: False
       apdb_config_url: parameters.apdb_config
       connections.exposure: initial_pvi
+      alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
       connections.coaddName: parameters.coaddName
   sampleSpatialMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask


### PR DESCRIPTION
Significantly faster than recalculating the PSF at the location of every source, but not as accurate