### PR TITLE
DM-46708: restore makeWarp configurations to working order

### DIFF
--- a/config/HSC/makeWarp.py
+++ b/config/HSC/makeWarp.py
@@ -8,14 +8,11 @@ import os.path
 # HACK: Throw away any changes imposed by obs configs.
 config.loadFromString(type(config)().saveToString())
 
-# Load configs shared between assembleCoadd and makeWarp
-config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
-
 config.makePsfMatched = True
 config.doApplySkyCorr = True
 
 config.modelPsf.defaultFwhm = 7.7
-config.warpAndPsfMatch.psfMatch.kernel['AL'].kernelSize = config.matchingKernelSize
-config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
-config.warpAndPsfMatch.warp.warpingKernelName = 'lanczos5'
-config.coaddPsf.warpingKernelName = 'lanczos5'
+config.warpAndPsfMatch.psfMatch.kernel["AL"].kernelSize = 29
+config.warpAndPsfMatch.psfMatch.kernel["AL"].alardSigGauss = [1.0, 2.0, 4.5]
+config.warpAndPsfMatch.warp.warpingKernelName = "lanczos5"
+config.coaddPsf.warpingKernelName = "lanczos5"

--- a/config/LSSTCam-imSim/makeWarp.py
+++ b/config/LSSTCam-imSim/makeWarp.py
@@ -30,12 +30,9 @@ import os.path
 # HACK: Throw away any changes imposed by obs configs.
 config.loadFromString(type(config)().saveToString())
 
-# Load configs shared between assembleCoadd and makeCoaddTempExp
-config.load(os.path.join(os.path.dirname(__file__), "coaddBase.py"))
-
 config.makePsfMatched = True
-config.warpAndPsfMatch.psfMatch.kernel['AL'].kernelSize = config.matchingKernelSize
-config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
+config.warpAndPsfMatch.psfMatch.kernel["AL"].kernelSize = 29
+config.warpAndPsfMatch.psfMatch.kernel["AL"].alardSigGauss = [1.0, 2.0, 4.5]
 config.modelPsf.defaultFwhm = 7.7
 
 # FUTURE: Set to True when we have sky background estimate


### PR DESCRIPTION
The configs for makeWarp were accidentally broken when the coaddBase config was (correctly) removed in favor of new configs for makeDirectWarp and makePsfMatchedWarp.  Now that we're letting makeWarp live a bit longer while we test its replacements off the main branch, we probably want its config overrides working again.