### PR TITLE
DM-47067: Enable alert generation in ap_pipe

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -74,6 +74,7 @@ tasks:
     config:
       doConfigureApdb: False
       apdb_config_url: parameters.apdb_config
+      doPackageAlerts: True  # Test alert generation, but don't output
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
       connections.exposure: initial_pvi
       connections.coaddName: parameters.coaddName

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -74,8 +74,8 @@ tasks:
     config:
       doConfigureApdb: False
       apdb_config_url: parameters.apdb_config
-      connections.exposure: initial_pvi
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
+      connections.exposure: initial_pvi
       connections.coaddName: parameters.coaddName
   sampleSpatialMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -95,6 +95,7 @@ tasks:
       doSolarSystemAssociation: False
       doConfigureApdb: False
       apdb_config_url: parameters.apdb_config
+      doPackageAlerts: True  # Test alert generation, but don't output
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.exposure: fakes_initial_pvi


### PR DESCRIPTION
This PR turns on alert generation (but not writing or distribution) in the base `ApPipe` pipeline. This ensures that this code is exercised and is counted in the run time (which can be significant, for crowded or noisy fields).