### PR TITLE
DM-47620 Adding single-frame fallback pipelines

### DIFF
--- a/pipelines/LSSTComCam/SingleFrame.yaml
+++ b/pipelines/LSSTComCam/SingleFrame.yaml
@@ -1,0 +1,8 @@
+description: >-
+  Single-frame pipeline for the case in which
+  no templates exist, specialized for LSSTComCam
+instrument: lsst.obs.lsst.LsstComCam
+imports:
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/SingleFrame.yaml
+tasks:
+  isr: lsst.ip.isr.IsrTaskLSST

--- a/pipelines/_ingredients/SingleFrame.yaml
+++ b/pipelines/_ingredients/SingleFrame.yaml
@@ -1,0 +1,19 @@
+description: Single-frame pipeline for the case in which no templates exist
+imports:
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+    include:
+      - processCcd
+      - initialPviCore
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+tasks:
+  ssSingleFrameAssociation:
+    class: lsst.ap.association.SsSingleFrameAssociationTask 
+subsets:
+  processCcd:
+    subset:
+      - isr
+      - calibrateImage
+      - ssSingleFrameAssociation
+    description: >
+      This adds ssSingleFrameAssociation to processCcd


### PR DESCRIPTION
My understanding of why I was instructed to make these changes in the particular structure I did: 

As-is, SingleFrame.yaml exists in `prompt_processing` but nowhere else. We want a system in which `ap_pipe` (and `ci_pipe` and `drp_pipe`) sit on top of everything else and describe pipeline functionality via yamls. All `prompt_processing` pipeline yamls should reference and modify counterparts in `ap_pipe`. At the moment, SingleFrame.yaml is a standalone `prompt_processing` pipeline, so in addition to adding single-frame association to it, I was asked to also move it into `ap_pipe` in a traditional LSSTComCam -> _ingredients reference chain.