### PR TITLE
DM-49875: rename task labels and dataset names for RFC-1088

### DIFF
--- a/bps/clustering/clustering_ApPipe.yaml
+++ b/bps/clustering/clustering_ApPipe.yaml
@@ -19,7 +19,7 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   singleFrame:
-    pipetasks: isr,calibrateImage,analyzeCalibrationMetrics
+    pipetasks: isr,calibrateImage,analyzePreliminarySummaryStats
     dimensions: visit,detector
     equalDimensions: visit:exposure
   diffim:

--- a/bps/clustering/clustering_ApPipe.yaml
+++ b/bps/clustering/clustering_ApPipe.yaml
@@ -19,16 +19,16 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   singleFrame:
-    pipetasks: isr,calibrateImage,initialPviCore
+    pipetasks: isr,calibrateImage,analyzeCalibrationMetrics
     dimensions: visit,detector
     equalDimensions: visit:exposure
   diffim:
-    pipetasks: retrieveTemplate,subtractImages,detectAndMeasure,diffimTaskCore,detectionTaskCore,filterDiaSrcCat,sampleSpatialMetrics,diffimTaskPlots,rbClassify,transformDiaSrcCat
+    pipetasks: rewarpTemplate,subtractImages,detectAndMeasureDiaSource,analyzeImageDifferenceMetrics,analyzeDiaSourceDetectionMetrics,filterDiaSource,makeSampledImageSubtractionMetrics,analyzeSampledImageSubtractionMetrics,computeReliability,standardizeDiaSource
     dimensions: visit,detector
   association:
-    pipetasks: getRegionTimeFromVisit,mpSkyEphemerisQuery,loadDiaCatalogs,diaPipe
+    pipetasks: getRegionTimeFromVisit,mpSkyEphemerisQuery,loadDiaCatalogs,associateApdb,analyzeLoadDiaCatalogsMetrics,analyzeDiaSourceAssociationMetrics,analyzeAssociateDiaSourceTiming
     dimensions: visit,detector
     equalDimensions: visit:group
   diaSrcDetectorAnalysis:
-    pipetasks: analyzeAssocDiaSrcCore,analyzeTrailedDiaSrcCore
+    pipetasks: analyzeAssociatedDiaSourceTable,analyzeTrailedDiaSourceTable
     dimensions: visit,detector

--- a/bps/clustering/clustering_ApPipeWithFakes.yaml
+++ b/bps/clustering/clustering_ApPipeWithFakes.yaml
@@ -19,7 +19,7 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   singleFrame:
-    pipetasks: isr,calibrateImage,analyzeCalibrationMetrics
+    pipetasks: isr,calibrateImage,analyzePreliminarySummaryStats
     dimensions: visit,detector
     equalDimensions: visit:exposure
   diffim:

--- a/bps/clustering/clustering_ApPipeWithFakes.yaml
+++ b/bps/clustering/clustering_ApPipeWithFakes.yaml
@@ -19,18 +19,18 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   singleFrame:
-    pipetasks: isr,calibrateImage,initialPviCore
+    pipetasks: isr,calibrateImage,analyzeCalibrationMetrics
     dimensions: visit,detector
     equalDimensions: visit:exposure
   diffim:
-    pipetasks: retrieveTemplate,inject_visit,subtractImages,detectAndMeasure,diffimTaskCore,detectionTaskCore,filterDiaSrcCat,sampleSpatialMetrics,diffimTaskPlots,rbClassify,transformDiaSrcCat
+    pipetasks: rewarpTemplate,inject_visit,subtractImages,detectAndMeasureDiaSource,analyzeImageDifferenceMetrics,analyzeDiaSourceDetectionMetrics,filterDiaSource,makeSampledImageSubtractionMetrics,analyzeSampledImageSubtractionMetrics,computeReliability,standardizeDiaSource
     dimensions: visit,detector
   association:
-    pipetasks: getRegionTimeFromVisit,mpSkyEphemerisQuery,loadDiaCatalogs,diaPipe
+    pipetasks: getRegionTimeFromVisit,mpSkyEphemerisQuery,loadDiaCatalogs,associateApdb,analyzeLoadDiaCatalogsMetrics,analyzeDiaSourceAssociationMetrics,analyzeAssociateDiaSourceTiming
     dimensions: visit,detector
     equalDimensions: visit:group
   diaSrcDetectorAnalysis:
-    pipetasks: analyzeAssocDiaSrcCore,injectedMatch,analyzeDiaFakesDetectorVisitCore,analyzeTrailedDiaSrcCore
+    pipetasks: analyzeAssociatedDiaSourceTable,injectedMatch,analyzeDiaFakesDetectorVisitCore,analyzeTrailedDiaSourceTable
     dimensions: visit,detector
   diaSrcVisitAnalysis:
     pipetasks: consolidateMatchDiaSrc,analyzeDiaFakesVisitCore

--- a/doc/lsst.ap.pipe/getting-started.rst
+++ b/doc/lsst.ap.pipe/getting-started.rst
@@ -49,7 +49,7 @@ For the AP Pipeline to successfully process data, the following must be present 
 - **Calibration products** (biases, flats, and possibly others, depending on the instrument)
 
 - **Template images** for difference imaging.
-  These are of type ``goodSeeingCoadd`` by default, but the AP pipeline can be configured to use other types (and :doc:`the Pipeline Tutorial <pipeline-tutorial>` does so).
+  These are of type ``template_coadd`` by default, but the AP pipeline can be configured to use other types (and :doc:`the Pipeline Tutorial <pipeline-tutorial>` does so).
 
 .. _ap_verify_ci_hits2015: https://github.com/lsst/ap_verify_ci_hits2015/
 

--- a/doc/lsst.ap.pipe/pipeline-bps.rst
+++ b/doc/lsst.ap.pipe/pipeline-bps.rst
@@ -150,10 +150,9 @@ And the result will be something of the form::
                                     UNKNO | MISFI | UNREA | READY | PENDI | RUNNI | DELET | HELD  | SUCCE | FAILE
   Total                                   0 |     0 |  3731 |  4766 |     0 |     0 |     0 |     0 | 69607 |  4267
   ----------------------------------------------------------------------------------------------------------------------
-  imageDifference                         0 |     0 | 15073 |     0 |     0 |     0 |     0 |     2 |  1448 |   165
-  diaPipe                                 0 |     0 |  7234 |     0 |  1007 |    60 |     0 |     0 |  6585 |  1802
+  subtractImages                          0 |     0 | 15073 |     0 |     0 |     0 |     0 |     2 |  1448 |   165
+  associateApdb                           0 |     0 |  7234 |     0 |  1007 |    60 |     0 |     0 |  6585 |  1802
   isr                                     0 |     0 | 16688 |     0 |     0 |     0 |     0 |     0 |     0 |     0
-  characterizeImage                       0 |     0 | 16688 |     0 |     0 |     0 |     0 |     0 |     0 |     0
-  calibrate                               0 |     0 | 16688 |     0 |     0 |     0 |     0 |     0 |     0 |     0
+  calibrateImage                          0 |     0 | 16688 |     0 |     0 |     0 |     0 |     0 |     0 |     0
 
 When your run is finished, the STATE will change from RUNNING to COMPLETED (or FAILED, if any quanta were unsuccessful).

--- a/pipelines/DECam/ApPipe.yaml
+++ b/pipelines/DECam/ApPipe.yaml
@@ -13,3 +13,23 @@ tasks:
     class: lsst.ip.isr.IsrTask
     config:
       file: $AP_PIPE_DIR/config/DECam/runIsrWithCrosstalk.py
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -23,4 +23,4 @@ tasks:
     class: lsst.ip.isr.IsrTask
     config:
       file: $AP_PIPE_DIR/config/DECam/runIsrWithCrosstalk.py
-      connections.outputExposure: postISRCCD
+      connections.outputExposure: post_isr_image

--- a/pipelines/DECam/ApPipeWithFakes.yaml
+++ b/pipelines/DECam/ApPipeWithFakes.yaml
@@ -12,9 +12,15 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
 
 parameters:
-  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
+  coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
+  fakesType: 'fakes_'
+  injected_prefix: 'fakes_'
+  injection_prefix: 'injection_'
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask
     config:
       file: $AP_PIPE_DIR/config/DECam/runIsrWithCrosstalk.py
+      connections.outputExposure: postISRCCD

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -7,3 +7,23 @@ description: End to end AP pipeline specialized for HSC
 instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/HSC/ApPipeWithFakes.yaml
+++ b/pipelines/HSC/ApPipeWithFakes.yaml
@@ -11,4 +11,9 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
 
 parameters:
-  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
+  coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
+  fakesType: 'fakes_'
+  injected_prefix: 'fakes_'
+  injection_prefix: 'injection_'

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -3,3 +3,23 @@ description: >-
 instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/LSSTCam-imSim/ApPipe.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipe.yaml
@@ -7,3 +7,23 @@ description: End to end AP pipeline specialized for ImSim.
 instrument: lsst.obs.lsst.LsstCamImSim
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
@@ -9,4 +9,9 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
 
 parameters:
-  apdb_config:  # YOU MUST CONFIGURE THIS BEFORE RUNNING THE PIPELINE
+  coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
+  fakesType: 'fakes_'
+  injected_prefix: 'fakes_'
+  injection_prefix: 'injection_'

--- a/pipelines/LSSTCam/ApPipe.yaml
+++ b/pipelines/LSSTCam/ApPipe.yaml
@@ -3,3 +3,23 @@ description: >-
 instrument: lsst.obs.lsst.LsstCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/LSSTCam/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam/ApPipeWithFakes.yaml
@@ -1,0 +1,100 @@
+description: HSC AP Pipeline with synthetic/fake sources. Templates are inputs.
+# Remember:
+# (0) Ensure median calibration products and template coadds exist for the data being processed
+# (1) Execute `apdb-cli create-sql`, e.g.,
+#     apdb-cli create-sql "sqlite:////project/user/association.db" apdb_config.py
+# (2) Run this pipeline, setting the apdb_config parameter to point to the new file
+
+instrument: lsst.obs.lsst.LsstCam
+imports:
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+    exclude:
+      - isr
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+    include:
+      - isr
+
+parameters:
+  coaddName: goodSeeing
+  # APDB config file must be user-specified
+  apdb_config:
+  fakesType: 'fakes_'
+  injected_prefix: 'fakes_'
+  injection_prefix: 'injection_'
+subsets:
+  apPipeSingleFrame:
+    subset:
+      - isr
+      - calibrateImage
+      - analyzeCalibrationMetrics
+    description: >-
+      The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
+      SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
+      is designed as a standalone alternative to ApPipeWithFakes.yaml.
+  processCcd:  # TODO: remove on DM-48428
+    subset:
+      - isr
+      - calibrateImage
+      - analyzeCalibrationMetrics
+    description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
+  apPipe:
+    subset:
+      - isr
+      - calibrateImage
+      - inject_visit
+      - loadDiaCatalogs
+      - rewarpTemplate
+      - subtractImages
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - associateApdb
+      - injectedMatchDiaSrc
+      - injectedMatchAssocDiaSrc
+      - consolidateMatchDiaSrc
+      - consolidateMatchAssocDiaSrc
+      - makeSampledImageSubtractionMetrics
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
+      - analyzeDiaFakesDetectorVisitCore
+      - analyzeAssocDiaFakesDetectorVisitCore
+      - analyzeDiaFakesVisitCore
+      - analyzeAssocDiaFakesVisitCore
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeLoadDiaCatalogsMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeSampledImageSubtractionMetrics
+      - analyzeCalibrationMetrics
+    description: >
+      An alias of ApPipe to use in higher-level pipelines.
+  prompt:
+    subset:
+      - isr
+      - calibrateImage
+      - inject_visit
+      - rewarpTemplate
+      - subtractImages
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
+      - associateApdb
+      - injectedMatchDiaSrc
+      - injectedMatchAssocDiaSrc
+      - consolidateMatchDiaSrc
+      - consolidateMatchAssocDiaSrc
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeCalibrationMetrics
+    description: >
+      Tasks necessary to turn raw images into APDB rows and alerts.
+      Requires preload subset to be run first.

--- a/pipelines/LSSTCam/ApPipeWithFakes.yaml
+++ b/pipelines/LSSTCam/ApPipeWithFakes.yaml
@@ -26,7 +26,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
@@ -35,7 +35,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
   apPipe:
     subset:
@@ -69,7 +69,7 @@ subsets:
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
       - analyzeSampledImageSubtractionMetrics
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   prompt:
@@ -94,7 +94,7 @@ subsets:
       - analyzeDiaSourceDetectionMetrics
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       Tasks necessary to turn raw images into APDB rows and alerts.
       Requires preload subset to be run first.

--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -3,3 +3,23 @@ description: >-
 instrument: lsst.obs.lsst.LsstComCam
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+contracts:
+  # Add contracts for calibrateImage here since they are not valid for the Fakes pipeline
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
+    msg: "calibrateImage.exposure != subtractImages.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
+    msg: "calibrateImage.footprints_stars != subtractImages.sources"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
+              analyzePreliminarySummaryStats.connections.ConnectionsClass(config=analyzePreliminarySummaryStats).data.name
+    msg: "calibrateImage.exposure != analyzePreliminarySummaryStats.data"
+  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
+              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
+    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -24,90 +24,96 @@ tasks:
     class: lsst.ap.association.LoadDiaCatalogsTask
     config:
       connections.regionTime: regionTimeInfo
-      connections.diaObjects: preloaded_diaObjects
-      connections.diaSources: preloaded_diaSources
-      connections.diaForcedSources: preloaded_diaForcedSources
+      connections.diaSources: preloaded_dia_source
+      connections.diaForcedSources: preloaded_dia_forced_source
+      connections.diaObjects: preloaded_dia_object
       apdb_config_url: parameters.apdb_config
   isr:
     class: lsst.ip.isr.IsrTask
     config:
-      connections.outputExposure: postISRCCD
+      connections.outputExposure: post_isr_image
       doBrighterFatter: False
   calibrateImage:
     class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
     config:
-      connections.exposures: postISRCCD
-      connections.initial_stars_schema: initial_stars_schema
-      connections.exposure: initial_pvi
-      connections.stars: initial_stars_detector
-      connections.stars_footprints: initial_stars_footprints_detector
+      connections.exposures: post_isr_image
+      connections.initial_stars_schema: single_visit_star_schema
+      connections.exposure: preliminary_visit_image
+      connections.stars: single_visit_star_unstandardized
+      connections.stars_footprints: single_visit_star_footprints
       connections.applied_photo_calib: initial_photoCalib_detector
-      connections.background: initial_pvi_background
-      connections.psf_stars_footprints: initial_psf_stars_footprints_detector
-      connections.psf_stars: initial_psf_stars_detector
+      connections.background: preliminary_visit_image_background
+      connections.psf_stars_footprints: single_visit_psf_star_footprints
+      connections.psf_stars: single_visit_psf_star
       connections.astrometry_matches: initial_astrometry_match_detector
       connections.photometry_matches: initial_photometry_match_detector
   rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.bbox: initial_pvi.bbox
-      connections.wcs: initial_pvi.wcs
-      connections.coaddExposures: "{fakesType}{coaddName}Coadd"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.fakesType: parameters.fakesType
+      connections.bbox: preliminary_visit_image.bbox
+      connections.wcs: preliminary_visit_image.wcs
+      connections.coaddExposures: template_coadd
+      connections.template: "{fakesType}template_detector"
   subtractImages:
     class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: "{fakesType}initial_pvi"
-      connections.sources: initial_stars_footprints_detector
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
-      connections.kernelSources: "{fakesType}{coaddName}Diff_psfMatchSources"
+      connections.fakesType: parameters.fakesType
+      connections.science: "{fakesType}preliminary_visit_image"
+      connections.sources: single_visit_star_footprints
+      connections.template: "{fakesType}template_detector"
+      connections.difference: "{fakesType}difference_image_predetection"
+      connections.matchedTemplate: "{fakesType}template_matched"
+      connections.psfMatchingKernel: "{fakesType}difference_kernel"
+      connections.kernelSources: "{fakesType}difference_kernel_sources"
       doApplyExternalCalibrations: False
   detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: "{fakesType}initial_pvi"
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
-      connections.outputSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
-      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
-      connections.subtractedMeasuredExposure: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.maskedStreaks: "{fakesType}{coaddName}Diff_streaks"
+      connections.fakesType: parameters.fakesType
+      connections.science: "{fakesType}preliminary_visit_image"
+      connections.matchedTemplate: "{fakesType}template_matched"
+      connections.difference: "{fakesType}difference_image_predetection"
+      connections.outputSchema: "{fakesType}dia_source_schema"
+      connections.diaSources: "{fakesType}dia_source_unfiltered"
+      connections.subtractedMeasuredExposure: "{fakesType}difference_image"
+      connections.maskedStreaks: "{fakesType}goodSeeingDiff_streaks"
       doSkySources: True
   filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.diaSourceCat: "{fakesType}{coaddName}Diff_diaSrc"
-      connections.filteredDiaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.rejectedDiaSources: "{fakesType}{coaddName}Diff_rejectedDiaSrc"
-      connections.diffImVisitInfo: "{fakesType}{coaddName}Diff_differenceExp.visitInfo"
-      connections.longTrailedSources: "{fakesType}{coaddName}Diff_longTrailedSrc"
+      connections.fakesType: parameters.fakesType
+      connections.diaSourceCat: "{fakesType}dia_source_unfiltered"
+      connections.filteredDiaSourceCat: "{fakesType}dia_source_unstandardized"
+      connections.rejectedDiaSources: "{fakesType}rejected_dia_source"
+      connections.diffImVisitInfo: "{fakesType}difference_image.visitInfo"
+      connections.longTrailedSources: "{fakesType}long_trailed_source_detector"
       doRemoveSkySources: True
   computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: "{fakesType}initial_pvi"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.classifications: "{fakesType}{coaddName}RealBogusSources"
+      connections.fakesType: parameters.fakesType
+      connections.science: "{fakesType}preliminary_visit_image"
+      connections.template: "{fakesType}template_detector"
+      connections.difference: "{fakesType}difference_image"
+      connections.diaSources: "{fakesType}dia_source_unstandardized"
+      connections.classifications: "{fakesType}dia_source_reliability"
       modelPackageStorageMode: butler
   standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.diaSourceSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
-      connections.diaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.reliability: "{fakesType}{coaddName}RealBogusSources"
-      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
+      connections.fakesType: parameters.fakesType
+      connections.diaSourceSchema: "{fakesType}dia_source_schema"
+      connections.diaSourceCat: "{fakesType}dia_source_unstandardized"
+      connections.diffIm: "{fakesType}difference_image"
+      connections.reliability: "{fakesType}dia_source_reliability"
+      connections.diaSourceTable: "{fakesType}dia_source_detector"
       doRemoveSkySources: True
       doIncludeReliability: True  # Output from computeReliability
       doUseApdbSchema: True  # Force the table columns to match the APDB definition in sdm_schemas
@@ -115,32 +121,33 @@ tasks:
     class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.dummy_visit: initial_stars_footprints_detector
+      connections.dummy_visit: single_visit_star_footprints
       connections.output: regionTimeInfo
   mpSkyEphemerisQuery:
     class: lsst.ap.association.MPSkyEphemerisQueryTask
     config:
       connections.predictedRegionTime: regionTimeInfo
-      connections.ssObjects: preloaded_SsObjects
+      connections.ssObjects: preloaded_ss_object
   associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.exposure: "{fakesType}initial_pvi"
-      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
-      connections.solarSystemObjectTable: preloaded_SsObjects
-      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.preloadedDiaObjects: preloaded_diaObjects
-      connections.preloadedDiaSources: preloaded_diaSources
-      connections.preloadedDiaForcedSources: preloaded_diaForcedSources
-      connections.associatedDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
-      connections.associatedSsSources: "{fakesType}{coaddName}Diff_associatedSsSources"
-      connections.unassociatedSsObjects: ssUnassociatedObjects
-      connections.diaForcedSources: "{fakesType}{coaddName}Diff_diaForcedSrc"
-      connections.diaObjects: "{fakesType}{coaddName}Diff_diaObject"
-      connections.newDiaSources: "{fakesType}{coaddName}Diff_newDiaSources"
-      connections.marginalDiaSources: "{fakesType}{coaddName}Diff_marginalDiaSources"
+      connections.fakesType: parameters.fakesType
+      connections.exposure: "{fakesType}preliminary_visit_image"
+      connections.diaSourceTable: "{fakesType}dia_source_detector"
+      connections.solarSystemObjectTable: preloaded_ss_object
+      connections.diffIm: "{fakesType}difference_image"
+      connections.template: "{fakesType}template_detector"
+      connections.preloadedDiaObjects: preloaded_dia_object
+      connections.preloadedDiaSources: preloaded_dia_source
+      connections.preloadedDiaForcedSources: preloaded_dia_forced_source
+      connections.associatedDiaSources: "{fakesType}dia_source_apdb"
+      connections.associatedSsSources: "{fakesType}ss_source_detector"
+      connections.unassociatedSsObjects: "{fakesType}ss_object_unassociated"
+      connections.diaForcedSources: "{fakesType}dia_forced_source_apdb"
+      connections.diaObjects: "{fakesType}dia_object_apdb"
+      connections.newDiaSources: "{fakesType}new_dia_source"
+      connections.marginalDiaSources: "{fakesType}marginal_new_dia_source"
       apdb_config_url: parameters.apdb_config
       doPackageAlerts: True  # Test alert generation, but don't output
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
@@ -148,20 +155,21 @@ tasks:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: "{fakesType}initial_pvi"
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
-      connections.spatiallySampledMetrics: "{fakesType}{coaddName}Diff_spatiallySampledMetrics"
+      connections.fakesType: parameters.fakesType
+      connections.science: "{fakesType}preliminary_visit_image"
+      connections.matchedTemplate: "{fakesType}template_matched"
+      connections.template: "{fakesType}template_detector"
+      connections.difference: "{fakesType}difference_image"
+      connections.diaSources: "{fakesType}dia_source_unstandardized"
+      connections.psfMatchingKernel: "{fakesType}difference_kernel"
+      connections.spatiallySampledMetrics: "{fakesType}difference_image_metrics"
 
 subsets:
   apPipeSingleFrame:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
@@ -170,7 +178,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
   apPipe:
     subset:
@@ -195,7 +203,7 @@ subsets:
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
       - analyzeSampledImageSubtractionMetrics
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   preload:
@@ -221,7 +229,7 @@ subsets:
       - analyzeDiaSourceDetectionMetrics
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       Tasks necessary to turn raw images into APDB rows and alerts.
       Requires preload subset to be run first.
@@ -248,21 +256,6 @@ contracts:
   - contract: loadDiaCatalogs.connections.ConnectionsClass(config=loadDiaCatalogs).diaForcedSources.name ==
               associateApdb.connections.ConnectionsClass(config=associateApdb).preloadedDiaForcedSources.name
     msg: "loadDiaCatalogs.diaForcedSources != associateApdb.preloadedDiaForcedSources"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
-              subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
-    msg: "calibrateImage.exposure != subtractImages.science"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
-              subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
-    msg: "calibrateImage.footprints_stars != subtractImages.sources"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
-              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
-    msg: "calibrateImage.exposure != computeReliability.science"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
-              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
-    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
-              analyzeCalibrationMetrics.connections.ConnectionsClass(config=analyzeCalibrationMetrics).data.name
-    msg: "calibrateImage.exposure != analyzeCalibrationMetrics.data"
   - contract: rewarpTemplate.connections.ConnectionsClass(config=rewarpTemplate).template.name ==
               subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
     msg: "rewarpTemplate.template != subtractImages.template"
@@ -318,9 +311,6 @@ contracts:
   - contract: standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diaSourceTable.name ==
               associateApdb.connections.ConnectionsClass(config=associateApdb).diaSourceTable.name
     msg: "standardizeDiaSource.diaSourceTable != associateApdb.diaSourceTable"
-  - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
-              getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
-    msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"
   - contract: getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).output.name ==
               mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).predictedRegionTime.name
     msg: "mpSkyEphemerisQuery.predictedRegionTime != getRegionTimeFromVisit.output"    

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -23,47 +23,91 @@ tasks:
   loadDiaCatalogs:
     class: lsst.ap.association.LoadDiaCatalogsTask
     config:
+      connections.regionTime: regionTimeInfo
+      connections.diaObjects: preloaded_diaObjects
+      connections.diaSources: preloaded_diaSources
+      connections.diaForcedSources: preloaded_diaForcedSources
       apdb_config_url: parameters.apdb_config
   isr:
     class: lsst.ip.isr.IsrTask
     config:
+      connections.outputExposure: postISRCCD
       doBrighterFatter: False
   calibrateImage:
     class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
+    config:
+      connections.exposures: postISRCCD
+      connections.initial_stars_schema: initial_stars_schema
+      connections.exposure: initial_pvi
+      connections.stars: initial_stars_detector
+      connections.stars_footprints: initial_stars_footprints_detector
+      connections.applied_photo_calib: initial_photoCalib_detector
+      connections.background: initial_pvi_background
+      connections.psf_stars_footprints: initial_psf_stars_footprints_detector
+      connections.psf_stars: initial_psf_stars_detector
+      connections.astrometry_matches: initial_astrometry_match_detector
+      connections.photometry_matches: initial_photometry_match_detector
   rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
       connections.bbox: initial_pvi.bbox
       connections.wcs: initial_pvi.wcs
+      connections.coaddExposures: "{fakesType}{coaddName}Coadd"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
   subtractImages:
     class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: initial_pvi
+      connections.science: "{fakesType}initial_pvi"
       connections.sources: initial_stars_footprints_detector
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
+      connections.kernelSources: "{fakesType}{coaddName}Diff_psfMatchSources"
       doApplyExternalCalibrations: False
   detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: initial_pvi
+      connections.science: "{fakesType}initial_pvi"
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
+      connections.outputSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
+      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
+      connections.subtractedMeasuredExposure: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.maskedStreaks: "{fakesType}{coaddName}Diff_streaks"
       doSkySources: True
   filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.diaSourceCat: "{fakesType}{coaddName}Diff_diaSrc"
+      connections.filteredDiaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.rejectedDiaSources: "{fakesType}{coaddName}Diff_rejectedDiaSrc"
+      connections.diffImVisitInfo: "{fakesType}{coaddName}Diff_differenceExp.visitInfo"
+      connections.longTrailedSources: "{fakesType}{coaddName}Diff_longTrailedSrc"
       doRemoveSkySources: True
   computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: initial_pvi
+      connections.science: "{fakesType}initial_pvi"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.classifications: "{fakesType}{coaddName}RealBogusSources"
       modelPackageStorageMode: butler
   standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.diaSourceSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
+      connections.diaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.reliability: "{fakesType}{coaddName}RealBogusSources"
+      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
       doRemoveSkySources: True
       doIncludeReliability: True  # Output from computeReliability
       doUseApdbSchema: True  # Force the table columns to match the APDB definition in sdm_schemas
@@ -71,13 +115,32 @@ tasks:
     class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
     config:
       connections.coaddName: parameters.coaddName
+      connections.dummy_visit: initial_stars_footprints_detector
+      connections.output: regionTimeInfo
   mpSkyEphemerisQuery:
     class: lsst.ap.association.MPSkyEphemerisQueryTask
+    config:
+      connections.predictedRegionTime: regionTimeInfo
+      connections.ssObjects: preloaded_SsObjects
   associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.exposure: initial_pvi
+      connections.exposure: "{fakesType}initial_pvi"
+      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
+      connections.solarSystemObjectTable: preloaded_SsObjects
+      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.preloadedDiaObjects: preloaded_diaObjects
+      connections.preloadedDiaSources: preloaded_diaSources
+      connections.preloadedDiaForcedSources: preloaded_diaForcedSources
+      connections.associatedDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
+      connections.associatedSsSources: "{fakesType}{coaddName}Diff_associatedSsSources"
+      connections.unassociatedSsObjects: ssUnassociatedObjects
+      connections.diaForcedSources: "{fakesType}{coaddName}Diff_diaForcedSrc"
+      connections.diaObjects: "{fakesType}{coaddName}Diff_diaObject"
+      connections.newDiaSources: "{fakesType}{coaddName}Diff_newDiaSources"
+      connections.marginalDiaSources: "{fakesType}{coaddName}Diff_marginalDiaSources"
       apdb_config_url: parameters.apdb_config
       doPackageAlerts: True  # Test alert generation, but don't output
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
@@ -85,7 +148,13 @@ tasks:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:
       connections.coaddName: parameters.coaddName
-      connections.science: initial_pvi
+      connections.science: "{fakesType}initial_pvi"
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
+      connections.spatiallySampledMetrics: "{fakesType}{coaddName}Diff_spatiallySampledMetrics"
 
 subsets:
   apPipeSingleFrame:

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -33,38 +33,38 @@ tasks:
   rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
+      connections.coaddName: parameters.coaddName
       connections.bbox: initial_pvi.bbox
       connections.wcs: initial_pvi.wcs
-      connections.coaddName: parameters.coaddName
   subtractImages:
     class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
     config:
+      connections.coaddName: parameters.coaddName
       connections.science: initial_pvi
       connections.sources: initial_stars_footprints_detector
-      connections.coaddName: parameters.coaddName
       doApplyExternalCalibrations: False
   detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
     config:
-      connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
+      connections.science: initial_pvi
       doSkySources: True
   filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
-      doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
+      doRemoveSkySources: True
   computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
-      modelPackageStorageMode: butler
-      connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
+      connections.science: initial_pvi
+      modelPackageStorageMode: butler
   standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
-      doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
+      doRemoveSkySources: True
       doIncludeReliability: True  # Output from computeReliability
       doUseApdbSchema: True  # Force the table columns to match the APDB definition in sdm_schemas
   getRegionTimeFromVisit:
@@ -76,16 +76,16 @@ tasks:
   associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      connections.coaddName: parameters.coaddName
+      connections.exposure: initial_pvi
       apdb_config_url: parameters.apdb_config
       doPackageAlerts: True  # Test alert generation, but don't output
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
-      connections.exposure: initial_pvi
-      connections.coaddName: parameters.coaddName
   makeSampledImageSubtractionMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:
-      connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
+      connections.science: initial_pvi
 
 subsets:
   apPipeSingleFrame:

--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -30,7 +30,7 @@ tasks:
       doBrighterFatter: False
   calibrateImage:
     class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
-  retrieveTemplate:
+  rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.bbox: initial_pvi.bbox
@@ -43,29 +43,29 @@ tasks:
       connections.sources: initial_stars_footprints_detector
       connections.coaddName: parameters.coaddName
       doApplyExternalCalibrations: False
-  detectAndMeasure:
+  detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
     config:
       connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
       doSkySources: True
-  filterDiaSrcCat:
+  filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
       doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
-  rbClassify:
+  computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       modelPackageStorageMode: butler
       connections.science: initial_pvi
       connections.coaddName: parameters.coaddName
-  transformDiaSrcCat:
+  standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       doRemoveSkySources: True
       connections.coaddName: parameters.coaddName
-      doIncludeReliability: True  # Output from rbClassify
+      doIncludeReliability: True  # Output from computeReliability
       doUseApdbSchema: True  # Force the table columns to match the APDB definition in sdm_schemas
   getRegionTimeFromVisit:
     class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
@@ -73,7 +73,7 @@ tasks:
       connections.coaddName: parameters.coaddName
   mpSkyEphemerisQuery:
     class: lsst.ap.association.MPSkyEphemerisQueryTask
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       apdb_config_url: parameters.apdb_config
@@ -81,7 +81,7 @@ tasks:
       alertPackager.useAveragePsf: True  # Speed up production processing; don't want as default or in ApPipeWithFakes
       connections.exposure: initial_pvi
       connections.coaddName: parameters.coaddName
-  sampleSpatialMetrics:
+  makeSampledImageSubtractionMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:
       connections.science: initial_pvi
@@ -92,7 +92,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - initialPviCore
+      - analyzeCalibrationMetrics
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
@@ -101,84 +101,84 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - initialPviCore
+      - analyzeCalibrationMetrics
     description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
   apPipe:
     subset:
       - loadDiaCatalogs
       - isr
       - calibrateImage
-      - retrieveTemplate
+      - rewarpTemplate
       - subtractImages
-      - detectAndMeasure
-      - filterDiaSrcCat
-      - rbClassify
-      - transformDiaSrcCat
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
       - getRegionTimeFromVisit
       - mpSkyEphemerisQuery
-      - diaPipe
-      - analyzeAssocDiaSrcCore
-      - analyzeTrailedDiaSrcCore
-      - sampleSpatialMetrics
-      - diffimTaskCore
-      - detectionTaskCore
-      - loadDiaCatalogsCore
-      - associationCore
-      - associationTiming
-      - diffimTaskPlots
-      - initialPviCore
+      - associateApdb
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
+      - makeSampledImageSubtractionMetrics
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeLoadDiaCatalogsMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeSampledImageSubtractionMetrics
+      - analyzeCalibrationMetrics
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   preload:
     subset:
       - loadDiaCatalogs
-      - loadDiaCatalogsCore
+      - analyzeLoadDiaCatalogsMetrics
       - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
     subset:
       - isr
       - calibrateImage
-      - retrieveTemplate
+      - rewarpTemplate
       - subtractImages
-      - detectAndMeasure
-      - filterDiaSrcCat
-      - rbClassify
-      - transformDiaSrcCat
-      - diaPipe
-      - analyzeAssocDiaSrcCore
-      - analyzeTrailedDiaSrcCore
-      - diffimTaskCore
-      - detectionTaskCore
-      - associationCore
-      - associationTiming
-      - initialPviCore
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
+      - associateApdb
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeCalibrationMetrics
     description: >
       Tasks necessary to turn raw images into APDB rows and alerts.
       Requires preload subset to be run first.
   afterburner:
     subset:
-      - sampleSpatialMetrics
-      - diffimTaskPlots
+      - makeSampledImageSubtractionMetrics
+      - analyzeSampledImageSubtractionMetrics
     description: >
       Tasks for QA and other non-real-time processing.
       Requires prompt subset to be run first.
 contracts:
-  - detectAndMeasure.doSkySources == transformDiaSrcCat.doRemoveSkySources
-  # Both loadDiaCatalogs and diaPipe connect to the APDB, so make sure they use the same configuration
-  - loadDiaCatalogs.apdb_config_url == diaPipe.apdb_config_url
+  - detectAndMeasureDiaSource.doSkySources == standardizeDiaSource.doRemoveSkySources
+  # Both loadDiaCatalogs and associateApdb connect to the APDB, so make sure they use the same configuration
+  - loadDiaCatalogs.apdb_config_url == associateApdb.apdb_config_url
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - contract: loadDiaCatalogs.connections.ConnectionsClass(config=loadDiaCatalogs).diaObjects.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).preloadedDiaObjects.name
-    msg: "loadDiaCatalogs.diaObjects != diaPipe.preloadedDiaObjects"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).preloadedDiaObjects.name
+    msg: "loadDiaCatalogs.diaObjects != associateApdb.preloadedDiaObjects"
   - contract: loadDiaCatalogs.connections.ConnectionsClass(config=loadDiaCatalogs).diaSources.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).preloadedDiaSources.name
-    msg: "loadDiaCatalogs.diaSources != diaPipe.preloadedDiaSources"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).preloadedDiaSources.name
+    msg: "loadDiaCatalogs.diaSources != associateApdb.preloadedDiaSources"
   - contract: loadDiaCatalogs.connections.ConnectionsClass(config=loadDiaCatalogs).diaForcedSources.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).preloadedDiaForcedSources.name
-    msg: "loadDiaCatalogs.diaForcedSources != diaPipe.preloadedDiaForcedSources"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).preloadedDiaForcedSources.name
+    msg: "loadDiaCatalogs.diaForcedSources != associateApdb.preloadedDiaForcedSources"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
               subtractImages.connections.ConnectionsClass(config=subtractImages).science.name
     msg: "calibrateImage.exposure != subtractImages.science"
@@ -186,82 +186,82 @@ contracts:
               subtractImages.connections.ConnectionsClass(config=subtractImages).sources.name
     msg: "calibrateImage.footprints_stars != subtractImages.sources"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
-              rbClassify.connections.ConnectionsClass(config=rbClassify).science.name
-    msg: "calibrateImage.exposure != rbClassify.science"
+              computeReliability.connections.ConnectionsClass(config=computeReliability).science.name
+    msg: "calibrateImage.exposure != computeReliability.science"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).science.name
-    msg: "calibrateImage.exposure != sampleSpatialMetrics.science"
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).science.name
+    msg: "calibrateImage.exposure != makeSampledImageSubtractionMetrics.science"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).exposure.name + ".summaryStats" ==
-              initialPviCore.connections.ConnectionsClass(config=initialPviCore).data.name
-    msg: "calibrateImage.exposure != initialPviCore.data"
-  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
+              analyzeCalibrationMetrics.connections.ConnectionsClass(config=analyzeCalibrationMetrics).data.name
+    msg: "calibrateImage.exposure != analyzeCalibrationMetrics.data"
+  - contract: rewarpTemplate.connections.ConnectionsClass(config=rewarpTemplate).template.name ==
               subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
-    msg: "retrieveTemplate.template != subtractImages.template"
-  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).template.name
-    msg: "retrieveTemplate.template != sampleSpatialMetrics.template"
+    msg: "rewarpTemplate.template != subtractImages.template"
+  - contract: rewarpTemplate.connections.ConnectionsClass(config=rewarpTemplate).template.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).template.name
+    msg: "rewarpTemplate.template != makeSampledImageSubtractionMetrics.template"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
-              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
-    msg: "subtractImages.difference != detectAndMeasure.difference"
+              detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).difference.name
+    msg: "subtractImages.difference != detectAndMeasureDiaSource.difference"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
-    msg: "subtractImages.science != detectAndMeasure.science"
+              detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).science.name
+    msg: "subtractImages.science != detectAndMeasureDiaSource.science"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-    msg: "subtractImages.template != diaPipe.template"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).template.name
+    msg: "subtractImages.template != associateApdb.template"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-    msg: "subtractImages.science != diaPipe.exposure"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).exposure.name
+    msg: "subtractImages.science != associateApdb.exposure"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).matchedTemplate.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).matchedTemplate.name
-    msg: "subtractImages.matchedTemplate != sampleSpatialMetrics.matchedTemplate"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-              filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
-    msg: "detectAndMeasure.diaSources != filterDiaSrcCat.diaSourceCat"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != rbClassify.difference"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != transformDiaSrcCat.diffIm"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != diaPipe.diffIm"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).difference.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != sampleSpatialMetrics.difference"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != transformDiaSrcCat.diaSourceCat"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).diaSources.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != sampleSpatialMetrics.diaSources"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).longTrailedSources.name ==
-      analyzeTrailedDiaSrcCore.connections.ConnectionsClass(config=analyzeTrailedDiaSrcCore).data.name
-    msg: "filterDiaSrcCat.longTrailedSources != analyzeTrailedDiaSrcCore.data"
-  - contract: (not transformDiaSrcCat.doIncludeReliability) or
-              (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
-               transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
-    msg: "rbClassify.classifications != transformDiaSrcCat.reliability"
-  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
-    msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).matchedTemplate.name
+    msg: "subtractImages.matchedTemplate != makeSampledImageSubtractionMetrics.matchedTemplate"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).diaSources.name ==
+              filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).diaSourceCat.name
+    msg: "detectAndMeasureDiaSource.diaSources != filterDiaSource.diaSourceCat"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).difference.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != computeReliability.difference"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diffIm.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != standardizeDiaSource.diffIm"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              associateApdb.connections.ConnectionsClass(config=associateApdb).diffIm.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != associateApdb.diffIm"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).difference.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != makeSampledImageSubtractionMetrics.difference"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).diaSources.name
+    msg: "filterDiaSource.filteredDiaSourceCat != computeReliability.diaSources"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diaSourceCat.name
+    msg: "filterDiaSource.filteredDiaSourceCat != standardizeDiaSource.diaSourceCat"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).diaSources.name
+    msg: "filterDiaSource.filteredDiaSourceCat != makeSampledImageSubtractionMetrics.diaSources"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).longTrailedSources.name ==
+      analyzeTrailedDiaSourceTable.connections.ConnectionsClass(config=analyzeTrailedDiaSourceTable).data.name
+    msg: "filterDiaSource.longTrailedSources != analyzeTrailedDiaSourceTable.data"
+  - contract: (not standardizeDiaSource.doIncludeReliability) or
+              (computeReliability.connections.ConnectionsClass(config=computeReliability).classifications.name ==
+               standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).reliability.name)
+    msg: "computeReliability.classifications != standardizeDiaSource.reliability"
+  - contract: standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diaSourceTable.name ==
+              associateApdb.connections.ConnectionsClass(config=associateApdb).diaSourceTable.name
+    msg: "standardizeDiaSource.diaSourceTable != associateApdb.diaSourceTable"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
               getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
     msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"
   - contract: getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).output.name ==
               mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).predictedRegionTime.name
     msg: "mpSkyEphemerisQuery.predictedRegionTime != getRegionTimeFromVisit.output"    
-  - contract: (not diaPipe.doSolarSystemAssociation) or
+  - contract: (not associateApdb.doSolarSystemAssociation) or
               (mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).ssObjects.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).solarSystemObjectTable.name)
-    msg: "mpSkyEphemerisQuery.ssObjects != diaPipe.solarSystemObjectTable"        
-  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
-              analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
-    msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"
-  - contract: sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).spatiallySampledMetrics.name ==
-              diffimTaskPlots.connections.ConnectionsClass(config=diffimTaskPlots).data.name
-    msg: "sampleSpatialMetrics.spatiallySampledMetrics != diffimTaskPlots.data"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).solarSystemObjectTable.name)
+    msg: "mpSkyEphemerisQuery.ssObjects != associateApdb.solarSystemObjectTable"        
+  - contract: associateApdb.connections.ConnectionsClass(config=associateApdb).associatedDiaSources.name ==
+              analyzeAssociatedDiaSourceTable.connections.ConnectionsClass(config=analyzeAssociatedDiaSourceTable).data.name
+    msg: "associateApdb.associatedDiaSources != analyzeAssociatedDiaSourceTable.data"
+  - contract: makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).spatiallySampledMetrics.name ==
+              analyzeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=analyzeSampledImageSubtractionMetrics).data.name
+    msg: "makeSampledImageSubtractionMetrics.spatiallySampledMetrics != analyzeSampledImageSubtractionMetrics.data"

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -29,14 +29,14 @@ tasks:
   inject_visit:
     class: lsst.source.injection.inject_visit.VisitInjectTask
     config:
-      external_psf: false
-      external_photo_calib: false
-      external_wcs: false
       connections.input_exposure: initial_pvi
       connections.output_exposure: fakes_initial_pvi
       connections.output_catalog: fakes_initial_pvi_catalog
       connections.injection_prefix: parameters.injection_prefix
       connections.injected_prefix: parameters.injected_prefix
+      external_psf: false
+      external_photo_calib: false
+      external_wcs: false
   loadDiaCatalogs:
     class: lsst.ap.association.LoadDiaCatalogsTask
     config:
@@ -67,16 +67,16 @@ tasks:
   filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
-      doRemoveSkySources: true
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      doRemoveSkySources: true
   computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
-      modelPackageStorageMode: butler
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
+      modelPackageStorageMode: butler
   standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -8,8 +8,8 @@ description: AP Pipeline with synthetic/fake sources. Templates are inputs.
 # - afterburner is metrics and other non-essential tasks that are skipped by Prompt Processing
 
 imports:
-  - location: $ANALYSIS_TOOLS_DIR/pipelines/apDetectorVisitQualityCore.yaml
   - location: $ANALYSIS_TOOLS_DIR/pipelines/apDetectorVisitFakesCore.yaml
+  - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
 
 parameters:
   coaddName: goodSeeing
@@ -20,158 +20,26 @@ parameters:
   injection_prefix: 'injection_'
 
 tasks:
-  isr:
-    class: lsst.ip.isr.IsrTask
-    config:
-      connections.outputExposure: postISRCCD
-      doBrighterFatter: False
-  calibrateImage:
-    class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
-    config:
-      connections.exposures: postISRCCD
-      connections.initial_stars_schema: initial_stars_schema
-      connections.exposure: initial_pvi
-      connections.stars: initial_stars_detector
-      connections.stars_footprints: initial_stars_footprints_detector
-      connections.applied_photo_calib: initial_photoCalib_detector
-      connections.background: initial_pvi_background
-      connections.psf_stars_footprints: initial_psf_stars_footprints_detector
-      connections.psf_stars: initial_psf_stars_detector
-      connections.astrometry_matches: initial_astrometry_match_detector
-      connections.photometry_matches: initial_photometry_match_detector
   inject_visit:
     class: lsst.source.injection.inject_visit.VisitInjectTask
     config:
-      connections.input_exposure: initial_pvi
-      connections.output_exposure: fakes_initial_pvi
-      connections.output_catalog: fakes_initial_pvi_catalog
+      connections.input_exposure: preliminary_visit_image
+      connections.output_exposure: fakes_preliminary_visit_image
+      connections.output_catalog: fakes_preliminary_visit_image_catalog
       connections.injection_prefix: parameters.injection_prefix
       connections.injected_prefix: parameters.injected_prefix
       external_psf: false
       external_photo_calib: false
       external_wcs: false
-  loadDiaCatalogs:
-    class: lsst.ap.association.LoadDiaCatalogsTask
-    config:
-      connections.regionTime: regionTimeInfo
-      connections.diaObjects: preloaded_diaObjects
-      connections.diaSources: preloaded_diaSources
-      connections.diaForcedSources: preloaded_diaForcedSources
-      apdb_config_url: parameters.apdb_config
-  rewarpTemplate:
-    class: lsst.ip.diffim.getTemplate.GetTemplateTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.bbox: initial_pvi.bbox
-      connections.wcs: initial_pvi.wcs
-      connections.coaddExposures: "{fakesType}{coaddName}Coadd"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-  subtractImages:
-    class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.science: fakes_initial_pvi
-      connections.sources: initial_stars_footprints_detector  # don't use the fakes for PSF-matching
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
-      connections.kernelSources: "{fakesType}{coaddName}Diff_psfMatchSources"
-      doApplyExternalCalibrations: false
-  detectAndMeasureDiaSource:
-    class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.science: fakes_initial_pvi
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
-      connections.outputSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
-      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
-      connections.subtractedMeasuredExposure: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.maskedStreaks: "{fakesType}{coaddName}Diff_streaks"
-      doSkySources: true
-  filterDiaSource:
-    class: lsst.ap.association.FilterDiaSourceCatalogTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.diaSourceCat: "{fakesType}{coaddName}Diff_diaSrc"
-      connections.filteredDiaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.rejectedDiaSources: "{fakesType}{coaddName}Diff_rejectedDiaSrc"
-      connections.diffImVisitInfo: "{fakesType}{coaddName}Diff_differenceExp.visitInfo"
-      connections.longTrailedSources: "{fakesType}{coaddName}Diff_longTrailedSrc"
-      doRemoveSkySources: true
-  computeReliability:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.science: fakes_initial_pvi
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.classifications: "{fakesType}{coaddName}RealBogusSources"
-      modelPackageStorageMode: butler
-  standardizeDiaSource:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.diaSourceSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
-      connections.diaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.reliability: "{fakesType}{coaddName}RealBogusSources"
-      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
-      doRemoveSkySources: True
-      doIncludeReliability: True  # Output from computeReliability
-  getRegionTimeFromVisit:
-    class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.dummy_visit: initial_stars_footprints_detector
-      connections.output: regionTimeInfo
-  mpSkyEphemerisQuery:
-    class: lsst.ap.association.MPSkyEphemerisQueryTask
-    config:
-      connections.predictedRegionTime: regionTimeInfo
-      connections.ssObjects: preloaded_SsObjects
-  associateApdb:
-    class: lsst.ap.association.DiaPipelineTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.exposure: fakes_initial_pvi
-      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
-      connections.solarSystemObjectTable: preloaded_SsObjects
-      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.preloadedDiaObjects: preloaded_diaObjects
-      connections.preloadedDiaSources: preloaded_diaSources
-      connections.preloadedDiaForcedSources: preloaded_diaForcedSources
-      connections.associatedDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
-      connections.associatedSsSources: "{fakesType}{coaddName}Diff_associatedSsSources"
-      connections.unassociatedSsObjects: ssUnassociatedObjects
-      connections.diaForcedSources: "{fakesType}{coaddName}Diff_diaForcedSrc"
-      connections.diaObjects: "{fakesType}{coaddName}Diff_diaObject"
-      connections.newDiaSources: "{fakesType}{coaddName}Diff_newDiaSources"
-      connections.marginalDiaSources: "{fakesType}{coaddName}Diff_marginalDiaSources"
-      doWriteAssociatedSources: True
-      doSolarSystemAssociation: False
-      apdb_config_url: parameters.apdb_config
-      doPackageAlerts: True  # Test alert generation, but don't output
   injectedMatchDiaSrc:
     class: lsst.ap.pipe.matchSourceInjected.MatchInjectedToDiaSourceTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      connections.injectedCat: fakes_initial_pvi_catalog
-      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
       connections.matchDiaSources: "{fakesType}{coaddName}Diff_matchDiaSrc"
+      connections.injectedCat: fakes_preliminary_visit_image_catalog
+      connections.diffIm: "{fakesType}difference_image"
+      connections.diaSources: "{fakesType}dia_source_unfiltered"
       matchDistanceArcseconds: 0.5
       trimBuffer: 50
   injectedMatchAssocDiaSrc:
@@ -179,7 +47,7 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      connections.assocDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
+      connections.assocDiaSources: "{fakesType}dia_source_apdb"
       connections.matchDiaSources: "{fakesType}{coaddName}Diff_matchDiaSrc"
       connections.matchAssocDiaSources: "{fakesType}{coaddName}Diff_matchAssocDiaSrc"
   consolidateMatchDiaSrc:
@@ -196,24 +64,12 @@ tasks:
       connections.catalogType: parameters.coaddName
       connections.inputCatalogs: "fakes_{catalogType}Diff_matchAssocDiaSrc"
       connections.outputCatalog: "fakes_{catalogType}Diff_matchAssocDiaSourceTable"
-  makeSampledImageSubtractionMetrics:
-    class: lsst.ip.diffim.SpatiallySampledMetricsTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.science: fakes_initial_pvi
-      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
-      connections.template: "{fakesType}{coaddName}Diff_templateExp"
-      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
-      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
-      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
-      connections.spatiallySampledMetrics: "{fakesType}{coaddName}Diff_spatiallySampledMetrics"
 subsets:
   apPipeSingleFrame:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
@@ -222,7 +78,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
   apPipe:
     subset:
@@ -256,7 +112,7 @@ subsets:
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
       - analyzeSampledImageSubtractionMetrics
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   preload:
@@ -287,7 +143,7 @@ subsets:
       - analyzeDiaSourceDetectionMetrics
       - analyzeDiaSourceAssociationMetrics
       - analyzeAssociateDiaSourceTiming
-      - analyzeCalibrationMetrics
+      - analyzePreliminarySummaryStats
     description: >
       Tasks necessary to turn raw images into APDB rows and alerts.
       Requires preload subset to be run first.

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -23,9 +23,22 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTask
     config:
+      connections.outputExposure: postISRCCD
       doBrighterFatter: False
   calibrateImage:
     class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
+    config:
+      connections.exposures: postISRCCD
+      connections.initial_stars_schema: initial_stars_schema
+      connections.exposure: initial_pvi
+      connections.stars: initial_stars_detector
+      connections.stars_footprints: initial_stars_footprints_detector
+      connections.applied_photo_calib: initial_photoCalib_detector
+      connections.background: initial_pvi_background
+      connections.psf_stars_footprints: initial_psf_stars_footprints_detector
+      connections.psf_stars: initial_psf_stars_detector
+      connections.astrometry_matches: initial_astrometry_match_detector
+      connections.photometry_matches: initial_photometry_match_detector
   inject_visit:
     class: lsst.source.injection.inject_visit.VisitInjectTask
     config:
@@ -40,22 +53,32 @@ tasks:
   loadDiaCatalogs:
     class: lsst.ap.association.LoadDiaCatalogsTask
     config:
+      connections.regionTime: regionTimeInfo
+      connections.diaObjects: preloaded_diaObjects
+      connections.diaSources: preloaded_diaSources
+      connections.diaForcedSources: preloaded_diaForcedSources
       apdb_config_url: parameters.apdb_config
   rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      connections.coaddExposures: goodSeeingCoadd
-      connections.wcs: initial_pvi.wcs
       connections.bbox: initial_pvi.bbox
+      connections.wcs: initial_pvi.wcs
+      connections.coaddExposures: "{fakesType}{coaddName}Coadd"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
   subtractImages:
     class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
-      connections.sources: initial_stars_footprints_detector
+      connections.sources: initial_stars_footprints_detector  # don't use the fakes for PSF-matching
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
+      connections.kernelSources: "{fakesType}{coaddName}Diff_psfMatchSources"
       doApplyExternalCalibrations: false
   detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
@@ -63,12 +86,23 @@ tasks:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceTempExp"
+      connections.outputSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
+      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
+      connections.subtractedMeasuredExposure: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.maskedStreaks: "{fakesType}{coaddName}Diff_streaks"
       doSkySources: true
   filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      connections.diaSourceCat: "{fakesType}{coaddName}Diff_diaSrc"
+      connections.filteredDiaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.rejectedDiaSources: "{fakesType}{coaddName}Diff_rejectedDiaSrc"
+      connections.diffImVisitInfo: "{fakesType}{coaddName}Diff_differenceExp.visitInfo"
+      connections.longTrailedSources: "{fakesType}{coaddName}Diff_longTrailedSrc"
       doRemoveSkySources: true
   computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
@@ -76,12 +110,21 @@ tasks:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.classifications: "{fakesType}{coaddName}RealBogusSources"
       modelPackageStorageMode: butler
   standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      connections.diaSourceSchema: "{fakesType}{coaddName}Diff_diaSrc_schema"
+      connections.diaSourceCat: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.reliability: "{fakesType}{coaddName}RealBogusSources"
+      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
       doRemoveSkySources: True
       doIncludeReliability: True  # Output from computeReliability
   getRegionTimeFromVisit:
@@ -89,24 +132,46 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      connections.dummy_visit: initial_stars_footprints_detector
+      connections.output: regionTimeInfo
   mpSkyEphemerisQuery:
     class: lsst.ap.association.MPSkyEphemerisQueryTask
+    config:
+      connections.predictedRegionTime: regionTimeInfo
+      connections.ssObjects: preloaded_SsObjects
   associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
+      connections.exposure: fakes_initial_pvi
+      connections.diaSourceTable: "{fakesType}{coaddName}Diff_diaSrcTable"
+      connections.solarSystemObjectTable: preloaded_SsObjects
+      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.preloadedDiaObjects: preloaded_diaObjects
+      connections.preloadedDiaSources: preloaded_diaSources
+      connections.preloadedDiaForcedSources: preloaded_diaForcedSources
+      connections.associatedDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
+      connections.associatedSsSources: "{fakesType}{coaddName}Diff_associatedSsSources"
+      connections.unassociatedSsObjects: ssUnassociatedObjects
+      connections.diaForcedSources: "{fakesType}{coaddName}Diff_diaForcedSrc"
+      connections.diaObjects: "{fakesType}{coaddName}Diff_diaObject"
+      connections.newDiaSources: "{fakesType}{coaddName}Diff_newDiaSources"
+      connections.marginalDiaSources: "{fakesType}{coaddName}Diff_marginalDiaSources"
       doWriteAssociatedSources: True
       doSolarSystemAssociation: False
       apdb_config_url: parameters.apdb_config
       doPackageAlerts: True  # Test alert generation, but don't output
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-      connections.exposure: fakes_initial_pvi
   injectedMatchDiaSrc:
     class: lsst.ap.pipe.matchSourceInjected.MatchInjectedToDiaSourceTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.injectedCat: fakes_initial_pvi_catalog
+      connections.diffIm: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.diaSources: "{fakesType}{coaddName}Diff_diaSrc"
+      connections.matchDiaSources: "{fakesType}{coaddName}Diff_matchDiaSrc"
       matchDistanceArcseconds: 0.5
       trimBuffer: 50
   injectedMatchAssocDiaSrc:
@@ -114,6 +179,9 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
+      connections.assocDiaSources: "{fakesType}{coaddName}Diff_assocDiaSrc"
+      connections.matchDiaSources: "{fakesType}{coaddName}Diff_matchDiaSrc"
+      connections.matchAssocDiaSources: "{fakesType}{coaddName}Diff_matchAssocDiaSrc"
   consolidateMatchDiaSrc:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
@@ -134,6 +202,12 @@ tasks:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
+      connections.matchedTemplate: "{fakesType}{coaddName}Diff_matchedExp"
+      connections.template: "{fakesType}{coaddName}Diff_templateExp"
+      connections.difference: "{fakesType}{coaddName}Diff_differenceExp"
+      connections.diaSources: "{fakesType}{coaddName}Diff_candidateDiaSrc"
+      connections.psfMatchingKernel: "{fakesType}{coaddName}Diff_psfMatchKernel"
+      connections.spatiallySampledMetrics: "{fakesType}{coaddName}Diff_spatiallySampledMetrics"
 subsets:
   apPipeSingleFrame:
     subset:

--- a/pipelines/_ingredients/ApPipeWithFakes.yaml
+++ b/pipelines/_ingredients/ApPipeWithFakes.yaml
@@ -41,7 +41,7 @@ tasks:
     class: lsst.ap.association.LoadDiaCatalogsTask
     config:
       apdb_config_url: parameters.apdb_config
-  retrieveTemplate:
+  rewarpTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
       connections.coaddName: parameters.coaddName
@@ -57,33 +57,33 @@ tasks:
       connections.science: fakes_initial_pvi
       connections.sources: initial_stars_footprints_detector
       doApplyExternalCalibrations: false
-  detectAndMeasure:
+  detectAndMeasureDiaSource:
     class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
       doSkySources: true
-  filterDiaSrcCat:
+  filterDiaSource:
     class: lsst.ap.association.FilterDiaSourceCatalogTask
     config:
       doRemoveSkySources: true
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-  rbClassify:
+  computeReliability:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       modelPackageStorageMode: butler
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       connections.science: fakes_initial_pvi
-  transformDiaSrcCat:
+  standardizeDiaSource:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       doRemoveSkySources: True
-      doIncludeReliability: True  # Output from rbClassify
+      doIncludeReliability: True  # Output from computeReliability
   getRegionTimeFromVisit:
     class: lsst.pipe.tasks.getRegionTimeFromVisit.GetRegionTimeFromVisitTask
     config:
@@ -91,7 +91,7 @@ tasks:
       connections.fakesType: parameters.fakesType
   mpSkyEphemerisQuery:
     class: lsst.ap.association.MPSkyEphemerisQueryTask
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doWriteAssociatedSources: True
@@ -128,7 +128,7 @@ tasks:
       connections.catalogType: parameters.coaddName
       connections.inputCatalogs: "fakes_{catalogType}Diff_matchAssocDiaSrc"
       connections.outputCatalog: "fakes_{catalogType}Diff_matchAssocDiaSourceTable"
-  sampleSpatialMetrics:
+  makeSampledImageSubtractionMetrics:
     class: lsst.ip.diffim.SpatiallySampledMetricsTask
     config:
       connections.coaddName: parameters.coaddName
@@ -139,7 +139,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - initialPviCore
+      - analyzeCalibrationMetrics
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and
@@ -148,7 +148,7 @@ subsets:
     subset:
       - isr
       - calibrateImage
-      - initialPviCore
+      - analyzeCalibrationMetrics
     description: Deprecated alias for apPipeSingleFrame, will be removed after v29.
   apPipe:
     subset:
@@ -156,39 +156,39 @@ subsets:
       - calibrateImage
       - inject_visit
       - loadDiaCatalogs
-      - retrieveTemplate
+      - rewarpTemplate
       - subtractImages
-      - detectAndMeasure
-      - filterDiaSrcCat
-      - rbClassify
-      - transformDiaSrcCat
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
       - getRegionTimeFromVisit
       - mpSkyEphemerisQuery
-      - diaPipe
+      - associateApdb
       - injectedMatchDiaSrc
       - injectedMatchAssocDiaSrc
       - consolidateMatchDiaSrc
       - consolidateMatchAssocDiaSrc
-      - sampleSpatialMetrics
-      - analyzeAssocDiaSrcCore
-      - analyzeTrailedDiaSrcCore
+      - makeSampledImageSubtractionMetrics
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
       - analyzeDiaFakesDetectorVisitCore
       - analyzeAssocDiaFakesDetectorVisitCore
       - analyzeDiaFakesVisitCore
       - analyzeAssocDiaFakesVisitCore
-      - diffimTaskCore
-      - detectionTaskCore
-      - loadDiaCatalogsCore
-      - associationCore
-      - associationTiming
-      - diffimTaskPlots
-      - initialPviCore
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeLoadDiaCatalogsMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeSampledImageSubtractionMetrics
+      - analyzeCalibrationMetrics
     description: >
       An alias of ApPipe to use in higher-level pipelines.
   preload:
     subset:
       - loadDiaCatalogs
-      - loadDiaCatalogsCore
+      - analyzeLoadDiaCatalogsMetrics
       - mpSkyEphemerisQuery
     description: Tasks that can be run before receiving raw images.
   prompt:
@@ -196,31 +196,31 @@ subsets:
       - isr
       - calibrateImage
       - inject_visit
-      - retrieveTemplate
+      - rewarpTemplate
       - subtractImages
-      - detectAndMeasure
-      - filterDiaSrcCat
-      - rbClassify
-      - transformDiaSrcCat
-      - diaPipe
+      - detectAndMeasureDiaSource
+      - filterDiaSource
+      - computeReliability
+      - standardizeDiaSource
+      - associateApdb
       - injectedMatchDiaSrc
       - injectedMatchAssocDiaSrc
       - consolidateMatchDiaSrc
       - consolidateMatchAssocDiaSrc
-      - analyzeAssocDiaSrcCore
-      - analyzeTrailedDiaSrcCore
-      - diffimTaskCore
-      - detectionTaskCore
-      - associationCore
-      - associationTiming
-      - initialPviCore
+      - analyzeAssociatedDiaSourceTable
+      - analyzeTrailedDiaSourceTable
+      - analyzeImageDifferenceMetrics
+      - analyzeDiaSourceDetectionMetrics
+      - analyzeDiaSourceAssociationMetrics
+      - analyzeAssociateDiaSourceTiming
+      - analyzeCalibrationMetrics
     description: >
       Tasks necessary to turn raw images into APDB rows and alerts.
       Requires preload subset to be run first.
   afterburner:
     subset:
-      - sampleSpatialMetrics
-      - diffimTaskPlots
+      - makeSampledImageSubtractionMetrics
+      - analyzeSampledImageSubtractionMetrics
       - analyzeDiaFakesDetectorVisitCore
       - analyzeAssocDiaFakesDetectorVisitCore
       - analyzeDiaFakesVisitCore
@@ -242,10 +242,10 @@ subsets:
     subset:
     - inject_visit
     - subtractImages
-    - detectAndMeasure
-    - transformDiaSrcCat
-    - rbClassify
-    - diaPipe
+    - detectAndMeasureDiaSource
+    - standardizeDiaSource
+    - computeReliability
+    - associateApdb
     - injectedMatchDiaSrc
     - injectedMatchAssocDiaSrc
     - consolidateMatchDiaSrc
@@ -257,80 +257,80 @@ subsets:
     description: >
       All tasks from the 'apPipe' subset impacted by source injection.
 contracts:
-  - contract: detectAndMeasure.doSkySources == transformDiaSrcCat.doRemoveSkySources
-  # Both loadDiaCatalogs and diaPipe connect to the APDB, so make sure they use the same configuration
-  - loadDiaCatalogs.apdb_config_url == diaPipe.apdb_config_url
+  - contract: detectAndMeasureDiaSource.doSkySources == standardizeDiaSource.doRemoveSkySources
+  # Both loadDiaCatalogs and associateApdb connect to the APDB, so make sure they use the same configuration
+  - loadDiaCatalogs.apdb_config_url == associateApdb.apdb_config_url
   # Inputs and outputs must match. For consistency, contracts are written in execution order:
   #     first task == second task, then sorted by (first, second)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
+  - contract: rewarpTemplate.connections.ConnectionsClass(config=rewarpTemplate).template.name ==
               subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
-    msg: "retrieveTemplate.template != subtractImages.template"
-  - contract: retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).template.name
-    msg: "retrieveTemplate.template != sampleSpatialMetrics.template"
+    msg: "rewarpTemplate.template != subtractImages.template"
+  - contract: rewarpTemplate.connections.ConnectionsClass(config=rewarpTemplate).template.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).template.name
+    msg: "rewarpTemplate.template != makeSampledImageSubtractionMetrics.template"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
-              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
-    msg: "subtractImages.difference != detectAndMeasure.difference"
+              detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).difference.name
+    msg: "subtractImages.difference != detectAndMeasureDiaSource.difference"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-              detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
-    msg: "subtractImages.science != detectAndMeasure.science"
+              detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).science.name
+    msg: "subtractImages.science != detectAndMeasureDiaSource.science"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-    msg: "subtractImages.template != diaPipe.template"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).template.name
+    msg: "subtractImages.template != associateApdb.template"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
-    msg: "subtractImages.science != diaPipe.exposure"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).exposure.name
+    msg: "subtractImages.science != associateApdb.exposure"
   - contract: subtractImages.connections.ConnectionsClass(config=subtractImages).matchedTemplate.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).matchedTemplate.name
-    msg: "subtractImages.matchedTemplate != sampleSpatialMetrics.matchedTemplate"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-              filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
-    msg: "detectAndMeasure.diaSources != filterDiaSrcCat.diaSourceCat"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != rbClassify.difference"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != transformDiaSrcCat.diffIm"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != diaPipe.diffIm"
-  - contract: detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).difference.name
-    msg: "detectAndMeasure.subtractedMeasuredExposure != sampleSpatialMetrics.difference"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != rbClassify.diaSources"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != transformDiaSrcCat.diaSourceCat"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
-              sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).diaSources.name
-    msg: "filterDiaSrcCat.filteredDiaSourceCat != sampleSpatialMetrics.diaSources"
-  - contract: (not transformDiaSrcCat.doIncludeReliability) or
-              (rbClassify.connections.ConnectionsClass(config=rbClassify).classifications.name ==
-               transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).reliability.name)
-    msg: "rbClassify.classifications != transformDiaSrcCat.reliability"
-  - contract: transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name
-    msg: "transformDiaSrcCat.diaSourceTable != diaPipe.diaSourceTable"
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).matchedTemplate.name
+    msg: "subtractImages.matchedTemplate != makeSampledImageSubtractionMetrics.matchedTemplate"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).diaSources.name ==
+              filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).diaSourceCat.name
+    msg: "detectAndMeasureDiaSource.diaSources != filterDiaSource.diaSourceCat"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).difference.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != computeReliability.difference"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diffIm.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != standardizeDiaSource.diffIm"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              associateApdb.connections.ConnectionsClass(config=associateApdb).diffIm.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != associateApdb.diffIm"
+  - contract: detectAndMeasureDiaSource.connections.ConnectionsClass(config=detectAndMeasureDiaSource).subtractedMeasuredExposure.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).difference.name
+    msg: "detectAndMeasureDiaSource.subtractedMeasuredExposure != makeSampledImageSubtractionMetrics.difference"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              computeReliability.connections.ConnectionsClass(config=computeReliability).diaSources.name
+    msg: "filterDiaSource.filteredDiaSourceCat != computeReliability.diaSources"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diaSourceCat.name
+    msg: "filterDiaSource.filteredDiaSourceCat != standardizeDiaSource.diaSourceCat"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).filteredDiaSourceCat.name ==
+              makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).diaSources.name
+    msg: "filterDiaSource.filteredDiaSourceCat != makeSampledImageSubtractionMetrics.diaSources"
+  - contract: (not standardizeDiaSource.doIncludeReliability) or
+              (computeReliability.connections.ConnectionsClass(config=computeReliability).classifications.name ==
+               standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).reliability.name)
+    msg: "computeReliability.classifications != standardizeDiaSource.reliability"
+  - contract: standardizeDiaSource.connections.ConnectionsClass(config=standardizeDiaSource).diaSourceTable.name ==
+              associateApdb.connections.ConnectionsClass(config=associateApdb).diaSourceTable.name
+    msg: "standardizeDiaSource.diaSourceTable != associateApdb.diaSourceTable"
   - contract: calibrateImage.connections.ConnectionsClass(config=calibrateImage).stars_footprints.name ==
               getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).dummy_visit.name
     msg: "calibrateImage.stars_footprints != getRegionTimeFromVisit.dummy_visit"
   - contract: getRegionTimeFromVisit.connections.ConnectionsClass(config=getRegionTimeFromVisit).output.name ==
               mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).predictedRegionTime.name
     msg: "mpSkyEphemerisQuery.predictedRegionTime != getRegionTimeFromVisit.output"
-  - contract: (not diaPipe.doSolarSystemAssociation) or
+  - contract: (not associateApdb.doSolarSystemAssociation) or
               (mpSkyEphemerisQuery.connections.ConnectionsClass(config=mpSkyEphemerisQuery).ssObjects.name ==
-              diaPipe.connections.ConnectionsClass(config=diaPipe).solarSystemObjectTable.name)
-    msg: "mpSkyEphemerisQuery.ssObjects != diaPipe.solarSystemObjectTable"
-  - contract: diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
-              analyzeAssocDiaSrcCore.connections.ConnectionsClass(config=analyzeAssocDiaSrcCore).data.name
-    msg: "diaPipe.associatedDiaSources != analyzeAssocDiaSrcCore.data"
-  - contract: filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).longTrailedSources.name ==
-              analyzeTrailedDiaSrcCore.connections.ConnectionsClass(config=analyzeTrailedDiaSrcCore).data.name
-    msg: "diaPipe.longTrailedSources != analyzeTrailedDiaSrcCore.data"
-  - contract: sampleSpatialMetrics.connections.ConnectionsClass(config=sampleSpatialMetrics).spatiallySampledMetrics.name ==
-              diffimTaskPlots.connections.ConnectionsClass(config=diffimTaskPlots).data.name
-    msg: "sampleSpatialMetrics.spatiallySampledMetrics != diffimTaskPlots.data"
+              associateApdb.connections.ConnectionsClass(config=associateApdb).solarSystemObjectTable.name)
+    msg: "mpSkyEphemerisQuery.ssObjects != associateApdb.solarSystemObjectTable"
+  - contract: associateApdb.connections.ConnectionsClass(config=associateApdb).associatedDiaSources.name ==
+              analyzeAssociatedDiaSourceTable.connections.ConnectionsClass(config=analyzeAssociatedDiaSourceTable).data.name
+    msg: "associateApdb.associatedDiaSources != analyzeAssociatedDiaSourceTable.data"
+  - contract: filterDiaSource.connections.ConnectionsClass(config=filterDiaSource).longTrailedSources.name ==
+              analyzeTrailedDiaSourceTable.connections.ConnectionsClass(config=analyzeTrailedDiaSourceTable).data.name
+    msg: "associateApdb.longTrailedSources != analyzeTrailedDiaSourceTable.data"
+  - contract: makeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=makeSampledImageSubtractionMetrics).spatiallySampledMetrics.name ==
+              analyzeSampledImageSubtractionMetrics.connections.ConnectionsClass(config=analyzeSampledImageSubtractionMetrics).data.name
+    msg: "makeSampledImageSubtractionMetrics.spatiallySampledMetrics != analyzeSampledImageSubtractionMetrics.data"

--- a/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+++ b/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
@@ -12,6 +12,7 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
+      connections.outputExposure: postISRCCD
       # Some instruments have this already in obs_lsst.
       # Here we turn if off for AP generally.
       doBrighterFatter: False

--- a/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
+++ b/pipelines/_ingredients/ApPipeWithIsrTaskLSST.yaml
@@ -12,7 +12,7 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
-      connections.outputExposure: postISRCCD
+      connections.outputExposure: post_isr_image
       # Some instruments have this already in obs_lsst.
       # Here we turn if off for AP generally.
       doBrighterFatter: False

--- a/pipelines/_ingredients/SingleFrame.yaml
+++ b/pipelines/_ingredients/SingleFrame.yaml
@@ -6,8 +6,8 @@ imports:
       - getRegionTimeFromVisit
       - mpSkyEphemerisQuery
 tasks:
-  ssSingleFrameAssociation:
-    class: lsst.ap.association.SsSingleFrameAssociationTask 
+  associateSolarSystemDirectSource:
+    class: lsst.ap.association.SsSingleFrameAssociationTask
 subsets:
   singleFrame:
     subset:
@@ -15,7 +15,7 @@ subsets:
       - calibrateImage
       - getRegionTimeFromVisit
       - mpSkyEphemerisQuery
-      - ssSingleFrameAssociation
-      - initialPviCore
+      - analyzeCalibrationMetrics
+      - associateSolarSystemDirectSource
     description: >
       An alias of SingleFrame to use in higher-level pipelines.

--- a/pipelines/_ingredients/SingleFrame.yaml
+++ b/pipelines/_ingredients/SingleFrame.yaml
@@ -8,6 +8,12 @@ imports:
 tasks:
   associateSolarSystemDirectSource:
     class: lsst.ap.association.SsSingleFrameAssociationTask
+    config:
+      connections.exposure: initial_pvi
+      connections.sourceTable: initial_stars_footprints_detector
+      connections.solarSystemObjectTable: preloaded_SsObjects
+      connections.associatedSsSources: ssSingleFrameAssociatedSources
+      connections.unassociatedSsObjects: ssSingleFrameUnassociatedObjects
 subsets:
   singleFrame:
     subset:

--- a/pipelines/_ingredients/SingleFrame.yaml
+++ b/pipelines/_ingredients/SingleFrame.yaml
@@ -9,11 +9,11 @@ tasks:
   associateSolarSystemDirectSource:
     class: lsst.ap.association.SsSingleFrameAssociationTask
     config:
-      connections.exposure: initial_pvi
-      connections.sourceTable: initial_stars_footprints_detector
-      connections.solarSystemObjectTable: preloaded_SsObjects
-      connections.associatedSsSources: ssSingleFrameAssociatedSources
-      connections.unassociatedSsObjects: ssSingleFrameUnassociatedObjects
+      connections.exposure: preliminary_visit_image
+      connections.sourceTable: single_visit_star_footprints
+      connections.solarSystemObjectTable: preloaded_ss_object
+      connections.associatedSsSources: ss_source_direct_detector
+      connections.unassociatedSsObjects: ss_object_direct_unassociated
 subsets:
   singleFrame:
     subset:
@@ -21,7 +21,7 @@ subsets:
       - calibrateImage
       - getRegionTimeFromVisit
       - mpSkyEphemerisQuery
-      - analyzeCalibrationMetrics
       - associateSolarSystemDirectSource
+      - analyzePreliminarySummaryStats
     description: >
       An alias of SingleFrame to use in higher-level pipelines.

--- a/pipelines/_ingredients/SingleFrameWithIsrTaskLSST.yaml
+++ b/pipelines/_ingredients/SingleFrameWithIsrTaskLSST.yaml
@@ -7,6 +7,7 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
+      connections.outputExposure: postISRCCD
       # Some instruments have this already in obs_lsst.
       # Here we turn if off for AP generally.
       doBrighterFatter: False

--- a/pipelines/_ingredients/SingleFrameWithIsrTaskLSST.yaml
+++ b/pipelines/_ingredients/SingleFrameWithIsrTaskLSST.yaml
@@ -7,7 +7,7 @@ tasks:
   isr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
-      connections.outputExposure: postISRCCD
+      connections.outputExposure: post_isr_image
       # Some instruments have this already in obs_lsst.
       # Here we turn if off for AP generally.
       doBrighterFatter: False

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -77,7 +77,7 @@ class PipelineDefintionsTestSuite(lsst.utils.tests.TestCase):
                     "bfk", "cti", "dnlLUT",
                     # Everything else
                     "skyMap", "gaia_dr3_20230707", "gaia_dr2_20200414", "ps1_pv3_3pi_20170110",
-                    "goodSeeingCoadd", "pretrainedModelPackage",
+                    "template_coadd", "pretrainedModelPackage",
                 }
                 if "WithFakes" in file:
                     expected_inputs.add("injection_catalog")


### PR DESCRIPTION
This is a major reorganization, so I tried to break it apart into multiple steps with self-contained commits. These can be rebased after review for a cleaner commit history, but I think they will make the changes easier to follow.
There are also separate commits for most of the ApPipe and ApPipeWithFakes pipelines, which appear more complicated now since we can't rely on the task defaults. This can be simplified in future work when we update the task defaults, or by moving the connections definitions into shared config files, such as in the current `config/DECam/runIsrWithCrosstalk.py`.