### PR TITLE
DM-54643: Fix optional pyproj import in test_pipelines.py

### DIFF
--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -24,7 +24,11 @@ import tempfile
 import unittest
 
 # need to import pyproj to prevent file handle leakage
-import pyproj  # noqa: F401
+# TODO: Remove import after completing DM-54643. Use DM-54656
+try:
+    import pyproj  # noqa: F401
+except ImportError:
+    pass
 
 import lsst.daf.butler.tests as butlerTests
 import lsst.pipe.base


### PR DESCRIPTION


Guard the pyproj import with a try/except block so that the test
module can be loaded even when pyproj is not installed. The import
was only needed to work around a file handle leakage issue and is
not required for the tests themselves to function.