### PR TITLE
DM-55341: Optimizations for daily batch

### DIFF
--- a/bps/clustering/clustering_Daytime.yaml
+++ b/bps/clustering/clustering_Daytime.yaml
@@ -20,29 +20,45 @@ clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   preload:
     pipetasks: mpSkyEphemerisQuery,getRegionTimeFromVisit
-    dimensions: group,detector
+    dimensions: group
+    partitionDimensions: detector
+    partitionMaxSize: 30
   preloadApdb:
     pipetasks: loadDiaCatalogs,analyzeLoadDiaCatalogsMetrics
-    dimensions: group,detector
+    dimensions: group
+    partitionDimensions: detector
+    partitionMaxSize: 30
   singleFrame:
     pipetasks: isr,calibrateImage,analyzePreliminarySummaryStats
-    dimensions: visit,detector
+    dimensions: visit
     equalDimensions: visit:exposure
+    partitionDimensions: detector
+    partitionMaxSize: 30
   diffim:
     pipetasks: buildTemplate,subtractImages,detectAndMeasureDiaSource,analyzeImageDifferenceMetrics,analyzeDiaSourceDetectionMetrics,filterDiaSource,computeReliability,filterDiaSourcePostReliability,standardizeDiaSource
-    dimensions: visit,detector
+    dimensions: visit
+    partitionDimensions: detector
+    partitionMaxSize: 10
   association:
     pipetasks: associateApdb,analyzeDiaSourceAssociationMetrics,analyzeAssociateDiaSourceTiming
-    dimensions: visit,detector
+    dimensions: visit
+    partitionDimensions: detector
+    partitionMaxSize: 10
   singleFrameMeasurement:
     pipetasks: singleFrameDetectAndMeasure
-    dimensions: visit,detector
+    dimensions: visit
+    partitionDimensions: detector
+    partitionMaxSize: 10
   diaSrcDetectorAnalysis:
     pipetasks: analyzeAssociatedDiaSourceTable,analyzeTrailedDiaSourceTable
-    dimensions: visit,detector
+    dimensions: visit
+    partitionDimensions: detector
+    partitionMaxSize: 10
   diffimMetrics:
     pipetasks: makeSampledImageSubtractionMetrics,analyzeSampledImageSubtractionMetrics
-    dimensions: visit,detector
+    dimensions: visit
+    partitionDimensions: detector
+    partitionMaxSize: 10
   consolidateVisit:
     pipetasks: consolidateVisitSummary,consolidateDiaSourceTable,analyzeVisitSampledImageSubtractionMetrics
     dimensions: visit

--- a/scripts/LSSTCam/submit_ap_daytime.sh
+++ b/scripts/LSSTCam/submit_ap_daytime.sh
@@ -104,9 +104,10 @@ DATA_QUERY="instrument='$INSTRUMENT' \
         --qgraph-datastore-records \
         -q "$FULL_QGRAPH"
 
-    echo "[$(date)] Step 2/3: pruning orphan loadDiaCatalogs quanta"
+    echo "[$(date)] Step 2/3: pruning orphan quanta"
     python -m lsst.ap.pipe.prune_orphan_preloads \
-        "$FULL_QGRAPH" "$PRUNED_QGRAPH"
+        "$FULL_QGRAPH" "$PRUNED_QGRAPH" \
+        --preload-label getRegionTimeFromVisit --anchor-label associateApdb
 
     echo "[$(date)] Step 3/3: submitting BPS workflow with pruned graph"
     bps submit "${AP_PIPE_DIR}/bps/LSSTCam/bps_Daytime.yaml" \


### PR DESCRIPTION
* Create bigger clusters, instead of per-visit-detector quanta.
* Prune `getRegionTimeFromVisit` in addition to `loadDiaCatalogs`.