### PR TITLE
DM-55426: Use --qgraph-datastore-records in AP Catchup script

### DIFF
--- a/scripts/LSSTCam/submit_ap_daytime.sh
+++ b/scripts/LSSTCam/submit_ap_daytime.sh
@@ -101,6 +101,7 @@ DATA_QUERY="instrument='$INSTRUMENT' \
         -c "parameters:apdb_config=${TMP_APDB}" \
         -c "associateApdb:doRunForcedMeasurement=False" \
         --dataset-query-constraint off \
+        --qgraph-datastore-records \
         -q "$FULL_QGRAPH"
 
     echo "[$(date)] Step 2/3: pruning orphan loadDiaCatalogs quanta"


### PR DESCRIPTION
bps uses run-qbb which requires datastore records to be present in the quantum graph. Datastore records are not stored in the quantum graph unless --qgraph-datastore-records is passed to pipetask qgraph.