### PR TITLE
Revert "Merge pull request #281 from lsst/tickets/DM-55369"

### DIFF
--- a/pipelines/_ingredients/ApPipe.yaml
+++ b/pipelines/_ingredients/ApPipe.yaml
@@ -208,7 +208,6 @@ subsets:
       - isr
       - calibrateImage
       - analyzePreliminarySummaryStats
-      - singleFrameDetectAndMeasure
     description: >-
       The prompt ApPipe tasks that make up single-frame processing. Not to be confused with the
       SingleFrame.yaml pipeline, which does more than just ApPipe single frame processing, and

--- a/pipelines/_ingredients/SingleFrame.yaml
+++ b/pipelines/_ingredients/SingleFrame.yaml
@@ -9,6 +9,5 @@ subsets:
       - isr
       - calibrateImage
       - analyzePreliminarySummaryStats
-      - singleFrameDetectAndMeasure
     description: >
       An alias of SingleFrame to use in higher-level pipelines.


### PR DESCRIPTION
`singleFrameDetectAndMeasure` should only run in daytime AP, which it does via the `afterburner` subset of ApPipe.yaml